### PR TITLE
Removed second parameter from roxygenize() on line 19.  The reason is tha

### DIFF
--- a/R/document.r
+++ b/R/document.r
@@ -16,7 +16,7 @@ document <- function(pkg = NULL, check = TRUE) {
     roxygenise(pkg$path, pkg$path, roclets = c("had", "collate", "namespace"))
   } else {
     # Standard version of roxygen
-    roxygenize(pkg$path, pkg$path)
+    roxygenize(pkg$path)
   }
   
   if (check) check_doc(pkg)


### PR DESCRIPTION
Removed second parameter from roxygenize() on line 19.  The reason is that the second parameter defaults to NULL, and is in fact a relative path reference, not an absolute path reference.
