### PR TITLE
load_deps also loads "suggests" packages

### DIFF
--- a/R/package-deps.r
+++ b/R/package-deps.r
@@ -4,11 +4,12 @@
 #'
 #' @param pkg package description, can be path or package name.  See
 #'   \code{\link{as.package}} for more information
+#' @param deps dependencies to be loaded (e.g. "depends", "imports", "suggests", "enhances")
 #' @keywords programming
 #' @export
-load_deps <- function(pkg = NULL) {
+load_deps <- function(pkg = NULL, deps = c("depends", "imports", "suggests")) {
   pkg <- as.package(pkg)
-  deps <- c(parse_deps(pkg$depends), parse_deps(pkg$imports))
+  deps <- unlist(lapply(pkg[deps], parse_deps))
   
   if (length(deps) == 0) return(invisible())
   


### PR DESCRIPTION
Hi Hadley,

Since "suggests" packages are needed/required for 'check'ing and 'test'ing, I adjusted the load_deps function so it loads also "suggests" packages. 

Best regards,

Edwin
