### PR TITLE
override of system.file

### DIFF
--- a/R/system.r
+++ b/R/system.r
@@ -23,3 +23,13 @@ R <- function(options, path = tempdir()) {
    
   in_dir(path, system_check(r_path, options, env))
 }
+
+# Internal override of system.file to ensure that code in the package depending on system.file works 
+system.file <- function(..., pkg=NULL, package = "base", lib.loc = NULL, mustWork = FALSE){
+  pkg <- as.package(pkg)
+  if (package == pkg$package){
+    file.path(normalizePath(pkg$path, winslash="/"), "inst", ...)
+  } else {
+    base::system.file(..., package=package, lib.loc=lib.loc, mustWork=mustWork)
+  }
+}


### PR DESCRIPTION
Hi Hadley,

One of my R packages uses `system.file` which gave problems with `devtools`, because `system.file` only finds installed package directories. So I made a version of `devtools` which overrides `system.file`, adding a "/inst" to the path when needed. 
This `system.file` is not exported. 

Best,

Edwin
