### PR TITLE
Bug fix for trailing '/' in find_package.

### DIFF
--- a/R/package.r
+++ b/R/package.r
@@ -50,6 +50,7 @@ find_package <- function(x) {
     desc_path <- file.path(x, "DESCRIPTION")
     file.exists(x) && file.exists(desc_path)
   }
+  x <- gsub('[/\\\\]+$', '', x, perl=TRUE)
   if (is_package_path(x)) {
     return(x)
   }


### PR DESCRIPTION
very minor change to fix the error that pops up from trying

``` r
install('devtools/')
```

rather than 

``` r
install('devtools')
```

That can often occur when using auto-complete for folder names.
