### PR TITLE
Switch order of arguments in show_rd

### DIFF
--- a/R/document.r
+++ b/R/document.r
@@ -53,16 +53,16 @@ check_doc <- function(pkg = NULL) {
 
 #' Show an Rd file in a package.
 #'
+#' @param file name of Rd file to open.  Can optionally omit Rd extension.
 #' @param pkg package description, can be path or package name.  See
 #'   \code{\link{as.package}} for more information
-#' @param file name of Rd file to open.  Can optionally omit Rd extension.
 #' @param ... additional arguments passed onto \code{\link[tools]{Rd2txt}}.
 #'   This is particular useful if you're checking macros and want to simulate
 #'   what happens when the package is built (\code{stage = "build"})
 #' @export
 #' @importFrom tools file_ext
 #' @importFrom tools Rd2txt
-show_rd <- function(pkg = NULL, file, ...) {
+show_rd <- function(file, pkg = NULL, ...) {
   pkg <- as.package(pkg)
   if (file_ext(file) == "") file <- paste(file, ".Rd", sep ="")
 

--- a/man/show_rd.Rd
+++ b/man/show_rd.Rd
@@ -2,14 +2,14 @@
 \alias{show_rd}
 \title{Show an Rd file in a package.}
 \usage{
-  show_rd(pkg = NULL, file, ...)
+  show_rd(file, pkg = NULL, ...)
 }
 \arguments{
-  \item{pkg}{package description, can be path or package
-  name.  See \code{\link{as.package}} for more information}
-
   \item{file}{name of Rd file to open.  Can optionally omit
   Rd extension.}
+
+  \item{pkg}{package description, can be path or package
+  name.  See \code{\link{as.package}} for more information}
 
   \item{...}{additional arguments passed onto
   \code{\link[tools]{Rd2txt}}.  This is particular useful


### PR DESCRIPTION
Allows to use `show_rd(filename)` from within a package directory when developing it, and be taken to the corresponding .Rd file, instead of having to write `show_rd(file=filename)`.

I don't know if it is too late for that or not but it would be a worthwhile time saver when developping a package.
