### PR TITLE
ensure that the repo passed to url is lowercase

### DIFF
--- a/R/install-bitbucket.r
+++ b/R/install-bitbucket.r
@@ -19,12 +19,18 @@ install_bitbucket <- function(repo, username, ref = "master", branch = NULL, ...
     warning("'branch' is deprecated. In the future, please use 'ref' instead.")
     ref <- branch
   }
+
+
+
   message("Installing bitbucket repo(s) ",
     paste(repo, ref, sep = "/", collapse = ", "),
     " from ",
     paste(username, collapse = ", "))
-
-  url <- paste("https://bitbucket.org/", username, "/", repo, "/get/", 
+  
+# convert repo to lower case in line with bitbucket convention
+  repo <- tolower(repo)
+  
+url <- paste("https://bitbucket.org/", username, "/", repo, "/get/", 
     ref, ".zip", sep = "")
   install_url(url, paste(ref, ".zip", sep = ""), ...)
 }


### PR DESCRIPTION
See http://stackoverflow.com/questions/12966600/install-bitbucket-in-devtools-case-sensitive

repo identifiers within url appear to be always lowercase, despite package name.
