### PR TITLE
call .onLoad with package name

### DIFF
--- a/R/run-loadhooks.r
+++ b/R/run-loadhooks.r
@@ -16,7 +16,7 @@ run_onload <- function(pkg = ".") {
   # Run .onLoad if it's defined. Set a flag 'onLoad' in the metadata
   if (exists(".onLoad", nsenv, inherits = FALSE) &&
      is.null(metadata$onLoad)) {
-    nsenv$.onLoad()
+    nsenv$.onLoad(libname=NULL, pkgname = pkg$package)
     metadata$onLoad <- TRUE
   }
 }


### PR DESCRIPTION
I updated the `run_onload` to call the package `.onLoad` function with the package name and the `lib.loc` parameter as an explicit `NULL`.  This allows for packages with java code to be loaded through load_all().  The `system.file(package = ...)` calls still do not work, but they did not work before either.  I would also like to see that fixed.
