### PR TITLE
`install_version` allows non-CRAN-like repositories

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -14,6 +14,10 @@ NEW FEATURES
   `auth_user` if it's not your package (i.e. it's not your `username`) (Fixes
   #116)
 
+* `install_version` now accepts `archive_structure` argument to indicate
+  whether the repository stores archived packages following the CRAN directory
+  structure. This is useful to load a specific version from a custom repository.
+
 * new `dev_help` function replaces `show_rd` and makes it easy to get help on
   any topic in a development package (i.e. a package loaded with `load_all`)
   (Fixes #110)

--- a/README.md
+++ b/README.md
@@ -35,7 +35,8 @@ Building and installing:
 
 * `install_github` installs an R package from github, `install_gitorious` from
   gitorious, `install_bitbucket` from bitbucket, and `install_url` from an
-  arbitrary url. `install_version` installs a specified version from cran,
+  arbitrary url. `install_version` installs a specified version from a given
+  repository.
 
 Creating a new package:
 

--- a/man/install_version.Rd
+++ b/man/install_version.Rd
@@ -4,7 +4,8 @@
 \usage{
   install_version(package, version = NULL,
     repos = getOption("repos"),
-    type = getOption("pkgType"), ...)
+    type = getOption("pkgType"), archive_structure = TRUE,
+    ...)
 }
 \arguments{
   \item{package}{package name}
@@ -14,6 +15,15 @@
   function simply calls \code{\link{install}}. Otherwise,
   it looks at the list of archived source tarballs and
   tries to install an older version instead.}
+
+  \item{archive_structure}{Does the repository have a
+  defined archive structure?  When TRUE, the function looks
+  for older versions of packages in the
+  src/contrib/Archive/packageName directory of the
+  repository, like on CRAN. Setting this to FALSE indicates
+  that all versions of all packages are located in the
+  src/contrib directory of the repository, which is usually
+  the case of custom repositories.}
 
   \item{...}{Other arguments passed on to
   \code{\link{install}}.}


### PR DESCRIPTION
The existing `install_version` function assumes a CRAN-like repository structure, which is hard to emulate for private repositories. The new version adds an `archive_structure` parameter which allows the user to install a specific version of the package if the package repository has a flat archive structure (i.e. all versions of every package are located in the same directory).

``` R
archive_structure = TRUE # CRAN-like package repository (with archive directory)
archive_structure = FALSE # non-CRAN-like repository
```
