### PR TITLE
Aren't able to load data set into R file and export to NAMESPACE

### DIFF
--- a/R/load-code.r
+++ b/R/load-code.r
@@ -15,7 +15,7 @@ load_code <- function(pkg = ".") {
   paths <- changed_files(r_files)
 
   tryCatch(
-    lapply(paths, sys.source, envir = env, chdir = TRUE,
+    lapply(paths, sys.source, envir = env, chdir = FALSE,
       keep.source = TRUE),
     error = function(e) {
       clear_cache()


### PR DESCRIPTION
I have a package where I want to load a data set, say `SPECIALDATA` saved in `dataset.rda` in the `data/` directory and save it into a R object using R code, say `loaddataset.R` in the `R/` directory. The code in `loaddataset.R` looks like this:

```
#' Load special data set
#' 
#' This data gives me some super duper stuff and I want it exported to this package's
#' NAMESPACE so that I can have it available to other upstream packages that import this
#' package. Lazy loading doesn't work for this.
#' 
#' @name SPECIALDATA
#' @keywords data
#' @export

SPECIALDATA <- eval(parse(text=load("data/dataset.rda")))
```

However, in master, this won't work because `load_code` calls `sys.source` changing directories to the `R/` directory. The relative reference in `loaddataset.R` doesn't work. Moreover, if I move `dataset.rda` to `R/` then `check()` or `R CMD check` removes it.

So to fix this, I've changed four characters in `load_code` so that `sys.source` doesn't change directories. The paths are absolute in any case, so it doesn't make any sense to do this (as far as I can tell). 

Also as far as I can tell, `sys.source` has never used `chdir=FALSE` in `load_code.R`.
