### PR TITLE
Fix bug when removing S4 classes with inheritance

### DIFF
--- a/R/remove-s4-class.r
+++ b/R/remove-s4-class.r
@@ -60,6 +60,9 @@ contains_backrefs <- function(classname, pkgname, contains) {
   # otherwise FALSE.
   has_subclass_ref <- function(class_a, pkg_a, class_b, pkg_b) {
     x <- getClassDef(class_a, package = pkg_a)
+    if (is.null(x))
+      return(FALSE)
+    
     subclass_ref <- x@subclasses[[class_b]]
 
     if(!is.null(subclass_ref) && subclass_ref@package == pkg_b) {


### PR DESCRIPTION
Since `devtools:::remove_s4_classes` iterates over classes in the package, the function `devtools:::contains_backrefs` can reference a slot on `NULL`. Added an `is.null` check to avoid this. 
