### PR TITLE
Update rtools.r

### DIFF
--- a/R/rtools.r
+++ b/R/rtools.r
@@ -239,7 +239,7 @@ version_info <- list(
   ),
   "3.0" = list(
     version_min = "2.15.2",
-    version_max = "3.0.0",
+    version_max = "3.0.1",
     path = c("bin", "gcc-4.6.3/bin")
   )
 )


### PR DESCRIPTION
With R-3.0.1 released, Rtools 3.0 is still the most current version of Rtools. Edited final element of version_info to reflect this.
