### PR TITLE
Support for installing package dependencies

### DIFF
--- a/R/install.r
+++ b/R/install.r
@@ -20,17 +20,22 @@
 #'   arguments to bew passed to \code{R CMD install}. This defaults to the
 #'   value of the option \code{"devtools.install.args"}.
 #' @param quiet if \code{TRUE} suppresses output from this function.
+#' @param dependencies \code{logical} indicating to also install uninstalled
+#'   packages which this \code{pkg} depends on/links to/suggests. See
+#'   argument \code{dependencies} of \code{\link{install.packages}}.
 #' @export
 #' @family package installation
 #' @seealso \code{\link{with_debug}} to install packages with debugging flags
 #'   set.
 #' @importFrom utils install.packages
 install <- function(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
-                    args = getOption("devtools.install.args"), quiet = FALSE) {
+                    args = getOption("devtools.install.args"), quiet = FALSE,
+                    dependencies = NA) {
+
   pkg <- as.package(pkg)
 
   if (!quiet) message("Installing ", pkg$package)
-  install_deps(pkg)
+  install_deps(pkg, dependencies = dependencies)
 
   # Build the package. If quick==TRUE, don't build vignettes
   if (local) {
@@ -55,7 +60,7 @@ install <- function(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
   invisible(TRUE)
 }
 
-install_deps <- function(pkg = ".") {
+install_deps <- function(pkg = ".", dependencies = NA) {
   pkg <- as.package(pkg)
   deps <- c(parse_deps(pkg$depends)$name, parse_deps(pkg$imports)$name,
     parse_deps(pkg$linkingto)$name)
@@ -68,7 +73,7 @@ install_deps <- function(pkg = ".") {
 
   message("Installing dependencies for ", pkg$package, ":\n",
     paste(deps, collapse = ", "))
-  install.packages(deps)
+  install.packages(deps, dependencies = dependencies)
   invisible(deps)
 }
 

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -5,7 +5,7 @@
   install(pkg = ".", reload = TRUE, quick = FALSE,
     local = TRUE,
     args = getOption("devtools.install.args"),
-    quiet = FALSE)
+    quiet = FALSE, dependencies = NA)
 }
 \arguments{
   \item{pkg}{package description, can be path or package
@@ -31,6 +31,11 @@
 
   \item{quiet}{if \code{TRUE} suppresses output from this
   function.}
+
+  \item{dependencies}{\code{logical} indicating to also
+  install uninstalled packages which this \code{pkg}
+  depends on/links to/suggests. See argument
+  \code{dependencies} of \code{\link{install.packages}}.}
 }
 \description{
   Uses \code{R CMD INSTALL} to install the package. Will


### PR DESCRIPTION
This adds an argument `dependencies` to the functions `install_deps` and `install` that is simply passed down to `install.packages`. This should provide the functionality mentioned in https://github.com/hadley/devtools/issues/285. All remaining `install_*` functions already have a `...` argument that is passed to `install` and therefore no further changes should be necessary.
