### PR TITLE
keep source in load_all

### DIFF
--- a/R/source.r
+++ b/R/source.r
@@ -20,8 +20,9 @@ source_one <- function(file, envir = parent.frame()) {
 
   lines <- readLines(file, warn = FALSE)
   srcfile <- srcfilecopy(file, lines, file.info(file)[1, "mtime"],
-    isFile = TRUE)
-  exprs <- parse(text = lines, n = -1, srcfile = srcfile)
+                         isFile = TRUE)
+  exprs <- parse(text = lines, n = -1,
+                 srcfile = srcfile, keep.source = TRUE)
 
   n <- length(exprs)
   if (n == 0L) return(invisible())


### PR DESCRIPTION
Hi Hadley,

`source_one` forgets to keep.source. As a consequence no references are given in error reports.

Thanks. 
