### PR TITLE
Four small fixes for function install_version

### DIFF
--- a/NEWS
+++ b/NEWS
@@ -1,6 +1,11 @@
 devtools 1.3.99
 ----------------
 
+* Adjusted `install_version()` to new meta data structure on CRAN.
+
+* Fixed bug so that `install_version()` works with version numbers that 
+  contain hyphens.
+
 devtools 1.3
 ----------------
 

--- a/R/install-version.r
+++ b/R/install-version.r
@@ -19,10 +19,6 @@ install_version <- function(package, version = NULL, repos = getOption("repos"),
   contriburl <- contrib.url(repos, type)
   available <- available.packages(contriburl)
 
-  if (!is.null(version)) {
-    version <- numeric_version(version)
-  }
-
   if (package %in% row.names(available)) {
     current.version <- available[package, 'Version']
     if (is.null(version) || version == current.version) {
@@ -31,7 +27,7 @@ install_version <- function(package, version = NULL, repos = getOption("repos"),
     }
   }
 
-  con <- gzcon(url(sprintf("%s/src/contrib/Archive.rds", repos), "rb"))
+  con <- gzcon(url(sprintf("%s/src/contrib/Meta/archive.rds", repos), "rb"))
   on.exit(close(con))
   archive <- readRDS(con)
 
@@ -46,9 +42,9 @@ install_version <- function(package, version = NULL, repos = getOption("repos"),
   } else {
     package.path <- paste(package, "/", package, "_", version, ".tar.gz",
       sep = "")
-    if (!(package.path %in% info)) {
-      stop(sprintf("version '%s' is invalid for package '%s'", package,
-        version))
+    if (!(package.path %in% row.names(info))) {
+      stop(sprintf("version '%s' is invalid for package '%s'", version,
+        package))
     }
   }
 


### PR DESCRIPTION
Calling function `install_version` as in
`install_version("Matrix", "1.0-9", repos = "http://cran.us.r-project.org")`
did not install the desired package due to the following problems:
- File "archive.rds" moved on CRAN.
- Using `numeric_version(version)` instead of `version` breaks the code for packages with hyphens in the version number.
- The package path is found in the row names of data frame `info`.

Additionally another commit fixes a mix up of 'version' and 'package' in an error message.
