### PR TITLE
Feature initial submission email

### DIFF
--- a/R/release.r
+++ b/R/release.r
@@ -85,12 +85,6 @@ release <- function(pkg = ".", check = TRUE) {
     new_submission <- ""
   }
     
-  if (menu("Is this a new submission?"))
-  if (yesno("Is this a new submission?"))
-    return(invisible())
-  else
-    return(invisible())
-  
   if (yesno("Ready to upload?"))
     return(invisible())
 


### PR DESCRIPTION
For new submissions, CRAN asks the user to read and agree to its policies; see http://cran.r-project.org/web/packages/policies.html

This patch alters `release`  to ask the user if it is a new submission and if so, asks if they have read and agreed to CRAN policies; adding a sentence stating as much if they do. 

I'm ambivalent as to whether this addition is a good idea. It maybe a good idea to pull up the page with CRAN policies using `browser`. 
