### PR TITLE
Look for the topmost folder after decompressing a file

### DIFF
--- a/R/decompress.r
+++ b/R/decompress.r
@@ -35,6 +35,5 @@ getdir <- function(path)  sub("/[^/]*$", "", path)
 # Given a list of files, returns the root (the topmost folder) 
 # getrootdir(c("path/to/file", "path/to/other/thing")) returns "path/to"
 getrootdir <- function(file_list) {
-  depths <- sapply(file_list, function(file) { nchar(gsub("[^/]", "", file)) })
-  getdir(file_list[which.min(depths)])
+  getdir(file_list[which.min(nchar(gsub("[^/]", "", file_list)))])
 }


### PR DESCRIPTION
When decompressing, the output folder is considered to be the folder in which the first file in the archive resides. However, for some archives, the first file in the archive does not reside in the topmost folder (e.g. consider a package which was zipped up without having `.git` removed; `package/.git/description` is treated as the package's description if it is packed first, even if `package/DESCRIPTION` exists). 

This change selects the path in the archive with the fewest separators ("/") to use as the base for the output folder. 
