### PR TITLE
install testthat from GitHub

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,3 +21,4 @@ env:
   - global:
     - WARNINGS_ARE_ERRORS=1
     - _R_CHECK_FORCE_SUGGESTS_=0
+    - BOOTSTRAP_LATEX=1


### PR DESCRIPTION
so that tests are actually run on Travis (they were simply skipped before)
- example for code with a failing test where no error is reported: https://travis-ci.org/krlmlr/devtools/builds/14834370
- after applying the patch (actually, reporting failure of something else): https://travis-ci.org/krlmlr/devtools/builds/14835799
  - ~~this pull request currently also fails, but includes code to dump logs~~
