### PR TITLE
devtools.desc.author and .license now in vogue

### DIFF
--- a/R/load.r
+++ b/R/load.r
@@ -174,9 +174,9 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
 #'
 #' @details
 #' To set the default author and licenses, set \code{options}
-#' \code{devtool.author} and \code{devtool.license}.  I use
-#' \code{options(devtools.author = '"Hadley Wickham <h.wickham@@gmail.com> [aut,cre]"',
-#'   devtools.license = "GPL-3")}.
+#' \code{devtools.desc.author} and \code{devtools.desc.license}.  I use
+#' \code{options(devtools.desc.author = '"Hadley Wickham <h.wickham@@gmail.com> [aut,cre]"',
+#'   devtools.desc.license = "GPL-3")}.
 #' @param path path to package root directory
 #' @param extra a named list of extra options to add to \file{DESCRIPTION}. 
 #'   Arguments that take a list 


### PR DESCRIPTION
documentation had it 'devtool.author' and 'devtool.license'; fixed
