### PR TITLE
Support direct specification of install.packages() argument Ncpus

### DIFF
--- a/R/check-cran.r
+++ b/R/check-cran.r
@@ -18,6 +18,7 @@
 #' @param bioconductor include bioconductor packages in checking?
 #' @param type binary package type of test
 #' @param threads number of concurrent threads to use for checking.
+#'   It defaults to the option \code{"Ncpus"} or \code{1} if unset.
 #' @param check_dir the directory in which the package is checked
 #' @return invisible \code{TRUE} if successful and no ERRORs or WARNINGS,
 #' @importFrom tools package_dependencies
@@ -32,7 +33,7 @@
 #' }
 check_cran <- function(pkgs, libpath = file.path(tempdir(), "R-lib"),
   srcpath = libpath, bioconductor = FALSE, type = getOption("pkgType"),
-  threads = 1, check_dir = tempfile("check_cran")) {
+  threads = getOption("Ncpus", 1), check_dir = tempfile("check_cran")) {
   stopifnot(is.character(pkgs))
   if (length(pkgs) == 0) return()
 

--- a/R/install.r
+++ b/R/install.r
@@ -40,6 +40,7 @@
 #'   It defaults to the option \code{"keep.source.pkgs"}.
 #' @param threads number of concurrent threads to use for installing 
 #'   dependencies.
+#'   It defaults to the option \code{"Ncpus"} or \code{1} if unset.
 #' @export
 #' @family package installation
 #' @seealso \code{\link{with_debug}} to install packages with debugging flags
@@ -49,7 +50,7 @@ install <- function(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
                     args = getOption("devtools.install.args"), quiet = FALSE,
                     dependencies = NA, build_vignettes = !quick,
                     keep_source = getOption("keep.source.pkgs"),
-                    threads = 1) {
+                    threads = getOptions("Ncpus", 1)) {
 
   pkg <- as.package(pkg)
 
@@ -88,7 +89,8 @@ install <- function(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
 #' @export
 #' @examples
 #' \dontrun{install_deps(".")}
-install_deps <- function(pkg = ".", dependencies = NA, threads = 1) {
+install_deps <- function(pkg = ".", dependencies = NA, 
+                         threads = getOption("Ncpus", 1)) {
   pkg <- as.package(pkg)
   deps <- if (identical(dependencies, NA)) {
     c("Depends", "Imports", "LinkingTo")
@@ -114,6 +116,6 @@ install_deps <- function(pkg = ".", dependencies = NA, threads = 1) {
 
   message("Installing dependencies for ", pkg$package, ":\n",
     paste(deps, collapse = ", "))
-  install.packages(deps, dependencies = dependencies, Ncpus=threads)
+  install.packages(deps, dependencies = dependencies, Ncpus = threads)
   invisible(deps)
 }

--- a/man/check_cran.Rd
+++ b/man/check_cran.Rd
@@ -3,8 +3,8 @@
 \title{Check a package from CRAN.}
 \usage{
 check_cran(pkgs, libpath = file.path(tempdir(), "R-lib"), srcpath = libpath,
-  bioconductor = FALSE, type = getOption("pkgType"), threads = 1,
-  check_dir = tempfile("check_cran"))
+  bioconductor = FALSE, type = getOption("pkgType"),
+  threads = getOption("Ncpus", 1), check_dir = tempfile("check_cran"))
 }
 \arguments{
   \item{pkgs}{Vector of package names - note that unlike
@@ -27,7 +27,8 @@ check_cran(pkgs, libpath = file.path(tempdir(), "R-lib"), srcpath = libpath,
   \item{type}{binary package type of test}
 
   \item{threads}{number of concurrent threads to use for
-  checking.}
+  checking.  It defaults to the option \code{"Ncpus"} or
+  \code{1} if unset.}
 
   \item{check_dir}{the directory in which the package is
   checked}

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -5,7 +5,8 @@
 install(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
   args = getOption("devtools.install.args"), quiet = FALSE,
   dependencies = NA, build_vignettes = !quick,
-  keep_source = getOption("keep.source.pkgs"))
+  keep_source = getOption("keep.source.pkgs"), threads = getOptions("Ncpus",
+  1))
 }
 \arguments{
   \item{pkg}{package description, can be path or package
@@ -48,6 +49,10 @@ install(pkg = ".", reload = TRUE, quick = FALSE, local = TRUE,
   from an installed package. This is useful for debugging
   (especially inside of RStudio).  It defaults to the
   option \code{"keep.source.pkgs"}.}
+
+  \item{threads}{number of concurrent threads to use for
+  installing dependencies.  It defaults to the option
+  \code{"Ncpus"} or \code{1} if unset.}
 }
 \description{
 Uses \code{R CMD INSTALL} to install the package. Will also

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -2,7 +2,8 @@
 \alias{install_deps}
 \title{Install package dependencies}
 \usage{
-install_deps(pkg = ".", dependencies = NA)
+install_deps(pkg = ".", dependencies = NA, threads = getOption("Ncpus",
+  1))
 }
 \arguments{
   \item{pkg}{package description, can be path or package
@@ -12,6 +13,10 @@ install_deps(pkg = ".", dependencies = NA)
   install uninstalled packages which this \code{pkg}
   depends on/links to/suggests. See argument
   \code{dependencies} of \code{\link{install.packages}}.}
+
+  \item{threads}{number of concurrent threads to use for
+  installing dependencies.  It defaults to the option
+  \code{"Ncpus"} or \code{1} if unset.}
 }
 \description{
 Install package dependencies


### PR DESCRIPTION
It is a little tedious to always write:

```
with_options(list(Ncpus = 4), install(...))
with_options(list(Ncpus = 4), install_deps(...))
```

Therefore I made it an argument (as already provided by `check_cran`).
