### PR TITLE
revdep_check: record package information

### DIFF
--- a/R/reverse-dependencies.r
+++ b/R/reverse-dependencies.r
@@ -33,7 +33,7 @@ revdep_maintainers <- function(pkg = ".") {
 #' @export
 revdep_check <- function(pkg = NULL, recursive = FALSE, ignore = NULL, ...) {
   pkgs <- revdep(pkg, recursive = recursive, ignore = ignore)
-  check_cran(pkgs, ...)
+  check_cran(pkgs, revdep_pkg = pkg, ...)
 }
 
 

--- a/man/check_cran.Rd
+++ b/man/check_cran.Rd
@@ -5,7 +5,8 @@
 \usage{
 check_cran(pkgs, libpath = file.path(tempdir(), "R-lib"), srcpath = libpath,
   bioconductor = FALSE, type = getOption("pkgType"),
-  threads = getOption("Ncpus", 1), check_dir = tempfile("check_cran"))
+  threads = getOption("Ncpus", 1), check_dir = tempfile("check_cran"),
+  revdep_pkg = NULL)
 }
 \arguments{
 \item{pkgs}{Vector of package names - note that unlike other \pkg{devtools}
@@ -27,6 +28,10 @@ redownload the packages every time you run the package.}
 It defaults to the option \code{"Ncpus"} or \code{1} if unset.}
 
 \item{check_dir}{the directory in which the package is checked}
+
+\item{revdep_pkg}{Optional name of a package for which this check is
+checking the reverse dependencies of. This is normally passed in from
+\code{\link{revdep_check}}, and is used only for logging.}
 }
 \value{
 invisible \code{TRUE} if successful and no ERRORs or WARNINGS,


### PR DESCRIPTION
Previously `revdep_check("foo")` didn't record the package name "foo", or the version of the foo. With this change, the following is added to the top of 00-summary.txt:

```
=========================================================================
Reverse dependency check for tourr 0.5.3
Commit 8952c3b3cf4c2d5e3d9084d248efe4ce07314cb8
=========================================================================
```
