### PR TITLE
Remind the user to send plain text email

### DIFF
--- a/R/release.r
+++ b/R/release.r
@@ -108,7 +108,8 @@ release <- function(pkg = ".", check = TRUE) {
   body <- release_email(pkg$package, new_pkg)
   subject <- paste("CRAN submission ", pkg$package, " ", pkg$version, sep = "")
   email("cran@r-project.org", subject, body)
-
+  message("Remember to send the email as plain text ASCII and not HTML.")
+  
   if (file.exists(file.path(pkg$path, ".git"))) {
     message("Don't forget to tag the release when the package is accepted!")
   }


### PR DESCRIPTION
Just got chided (by guess who) in my last CRAN submission for sending the email as HTML and not plain text. It may be just me, but I wasn't aware of the policy, and since most email clients default to HTML these days, it may be a good idea to add this message.
