### PR TITLE
Ignore code files included in .Rbuildignore

### DIFF
--- a/R/load-code.r
+++ b/R/load-code.r
@@ -60,6 +60,21 @@ find_code <- function(pkg = ".") {
 
     r_files <- union(collate, r_files)
   }
+  
+  ## are any of these in .Rbuildignore?
+  path <- file.path(pkg$path, ".Rbuildignore")
+  if (file.exists(path)) {
+    ignore <- readLines(path, warn = FALSE)
+    ignore <- sub("^\\^","",ignore) # allow partial matching
+    drop <- logical(length(r_files))
+    for(ignore.file in ignore) {
+      m <- grep(ignore.file, r_files)
+      if(length(m))
+        drop[m] <- TRUE
+    }
+    r_files <- r_files[ !drop ]
+  }
+  
   r_files
 }
 


### PR DESCRIPTION
I have a file in my R/ directory that creates the files needed to go in the data/ directory.  I want to keep it with the package, but I don't want it in the package, so I add it to .Rbuildignore.  It takes a long time to run, and I also don't want it source()'d by load_all().  This change makes code files listed in .Rbuildignore be ignored by find_code(), and hence by load_all().
