### PR TITLE
updated documentation: roclet names, seealso

### DIFF
--- a/R/document.r
+++ b/R/document.r
@@ -1,14 +1,19 @@
 #' Use roxygen to make documentation.
 #'
+#' This function is a wrapper for the \code{\link{roxygenize}} function
+#' from the package \code{roxygen2}. 
 #' @param pkg package description, can be path or package name.  See
 #'   \code{\link{as.package}} for more information
 #' @param clean if \code{TRUE} will automatically clear all roxygen caches
 #'   and delete current \file{man/} contents to ensure that you have the
 #'   freshest version of the documentation.
-#' @param roclets character vector of roclet names to apply to package
+#' @param roclets character vector passed to roxygneise indicating roclets to update
+#' valid arguments include "rd", "collate", and "namespace" 
+#  and Rd files, 
 #' @param reload if \code{TRUE} uses \code{load_all} to reload the package
 #'   prior to documenting.  This is important because \pkg{roxygen2} uses
 #'   introspection on the code objects to determine how to document them.
+#' @seealso \code{\link{roxygenize}}\code{vignette("roxygen2", package = "roxygen2")}
 #' @keywords programming
 #' @export
 document <- function(pkg = ".", clean = FALSE,


### PR DESCRIPTION
... because I often find myself looking up the arguments to roclets, the goal is for `c("collate", "namespace", "rd")` to show up automatically when I type `'document(' -> Tab` in Rstudio.

While here, I also added references to roxygen2 in function description and @seealso
