### PR TITLE
a vignette engine is of the form pkg::engine_name

### DIFF
--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -73,7 +73,7 @@ use_knitr <- function(pkg = ".") {
   message(
     "Put .Rmd in vignettes/. Each must include:\n",
     "<!-- \n",
-    "%\\VignetteEngine{knitr}\n",
+    "%\\VignetteEngine{knitr::knitr}\n",
     "%\\VignetteIndexEntry{Vignette title}\n",
     "-->\n"
   )


### PR DESCRIPTION
Although Duncan chose the confusing separator `::` (which is merely a separator and has nothing to do with namespace), we have to accept it...
