### PR TITLE
fix incorrect field name of pkg object

### DIFF
--- a/R/install-min.r
+++ b/R/install-min.r
@@ -18,5 +18,5 @@ install_min <- function(pkg = ".", dest, components = NULL, args = NULL, quiet =
     args
   ), quiet = quiet)
 
-  invisible(file.path(dest, pkg$name))
+  invisible(file.path(dest, pkg$package))
 }


### PR DESCRIPTION
I think that name field does not exist in object pkg. It must be package
