### PR TITLE
fix three documentation typos

### DIFF
--- a/R/check.r
+++ b/R/check.r
@@ -1,9 +1,9 @@
 #' Build and check a package, cleaning up automatically on success.
 #'
 #' \code{check} automatically builds and checks a source package, using all
-#' know best practices. Passing \code{R CMD check} is essential if you want to
-#' submit your package to CRAN: you must not have an ERRORs or WARNINGs, and you
-#' want to ensure that there are as few NOTEs as possible.  If you are not
+#' known best practices. Passing \code{R CMD check} is essential if you want to
+#' submit your package to CRAN: you must not have any ERRORs or WARNINGs, and
+#' you want to ensure that there are as few NOTEs as possible.  If you are not
 #' submitting to CRAN, at least ensure that there are no ERRORs: these
 #' typically represent serious problems.
 #'
@@ -14,7 +14,7 @@
 #'
 #' @section Environment variables:
 #'
-#' Devtools does it's best to set up an environment that combines best practices
+#' Devtools does its best to set up an environment that combines best practices
 #' with how check works on CRAN. This includes:
 #'
 #' \itemize{


### PR DESCRIPTION
"know" -> "known" and
"must not have an ERRORs" -> "must not have _any_ ERRORs"
"it's" -> "its"
