### PR TITLE
The R CMD option rebuild vingettes has been renamed build vingettes

### DIFF
--- a/R/check.r
+++ b/R/check.r
@@ -104,7 +104,7 @@ check_r_cmd <- function(built_path = NULL, cran = TRUE, check_version = FALSE,
   if (!nzchar(Sys.which("pdflatex"))) {
     message("pdflatex not found! Not building PDF manual or vignettes.\n",
       "If you are planning to release this package, please run a check with manual and vignettes beforehand.\n")
-    opts <- c(opts, "--no-rebuild-vignettes", "--no-manual")
+    opts <- c(opts, "--no-build-vignettes", "--no-manual")
   }
 
   opts <- paste(paste(opts, collapse = " "), paste(args, collapse = " "))


### PR DESCRIPTION
Not exactly sure what happened here, but looks like some code from v1.0 got merged in?

(Here's the original fix](https://github.com/hadley/devtools/commit/bf273014dd822c775fe8e5e1704bf81e6013ce96)
