### PR TITLE
Add github user/repo to session_info()'s output

### DIFF
--- a/R/session-info.r
+++ b/R/session-info.r
@@ -121,7 +121,10 @@ pkg_source <- function(pkg) {
   desc <- packageDescription(pkg)
 
   if (!is.null(desc$GithubSHA1)) {
-    str <- paste0("Github (", substr(desc$GithubSHA1, 1, 7), ")")
+    str <- paste0("Github (",
+                  desc$GithubUsername, "/",
+                  desc$GithubRepo, "@",
+                  substr(desc$GithubSHA1, 1, 7), ")")
   } else if (!is.null(desc$Repository)) {
     repo <- desc$Repository
 


### PR DESCRIPTION
As I understand `session_info`'s main use is to be able to install the same versions of the listed packages later. Unless I am missing something, packages installed from Github need the username and the repo name for this. This PR adds them. Instead of this:

``` r
Packages-----------------------------------------------------------------------
 package      * version  source          
 devtools     * 1.5.0.99 local           
 digest         0.6.4    CRAN (R 3.1.0)  
 evaluate       0.5.5    CRAN (R 3.1.0)  
 httr           0.4      CRAN (R 3.1.1)  
 magrittr       1.1.0    Github (8320efc)
 memoise        0.2.1    CRAN (R 3.1.0)  
 RCurl          1.95.4.3 CRAN (R 3.1.1)  
 rstudioapi     0.1      CRAN (R 3.1.0)  
 stringr        0.6.2    CRAN (R 3.1.0)  
 whisker        0.3.2    CRAN (R 3.1.0)  
```

you will get this:

``` r
Packages-----------------------------------------------------------------------
 package    * version  source                           
 devtools   * 1.5.0.99 local                            
 digest       0.6.4    CRAN (R 3.1.0)                   
 evaluate     0.5.5    CRAN (R 3.1.0)                   
 httr         0.4      CRAN (R 3.1.1)                   
 magrittr   * 1.1.0    Github (smbache/magrittr@8320efc)
 memoise      0.2.1    CRAN (R 3.1.0)                   
 RCurl        1.95.4.3 CRAN (R 3.1.1)                   
 rstudioapi   0.1      CRAN (R 3.1.0)                   
 stringr      0.6.2    CRAN (R 3.1.0)                   
 whisker      0.3.2    CRAN (R 3.1.0)                   

```
