### PR TITLE
Recognize Bioconductor packages in session_info()

### DIFF
--- a/R/session-info.r
+++ b/R/session-info.r
@@ -134,6 +134,8 @@ pkg_source <- function(pkg) {
 
     repo
 
+  } else if (!is.null(desc$biocViews)) {
+    "Bioconductor"
   } else {
     "local"
   }


### PR DESCRIPTION
These packages _must_ have a 'biocViews' field in
`DESCRIPTION`, according to the How-to at
http://www.bioconductor.org/developers/how-to/biocViews/

I cannot see an easy way to recognize the Bioconductor release, unfortunately, but their packages increase version numbers in each release, so the version number should be unique. 

Example output:

``` r
Packages-------------------------------------------------------------------------
 package      * version     source          
 Biobase      * 2.24.0      Bioconductor    
 BiocGenerics * 0.10.0      Bioconductor    
 devtools     * 1.5.0.99    local           
 digest         0.6.4       CRAN (R 3.1.0)  
 evaluate       0.5.5       CRAN (R 3.1.0)  
 formatR        0.10        CRAN (R 3.1.0)  
 httr           0.4         CRAN (R 3.1.1)  
 igraph         0.7.999.175 local           
 knitr          1.6         CRAN (R 3.1.0)  
 magrittr     * 1.1.0       Github (8320efc)
 markdown       0.7.2       CRAN (R 3.1.1)  
```
