### PR TITLE
Revert to using GitHub archive URLs instead of GitHub API for install_github

### DIFF
--- a/R/install-github.r
+++ b/R/install-github.r
@@ -97,9 +97,8 @@ github_get_conn <- function(repo, username = NULL, ref = "master",
     "from",
     paste(username, collapse = ", "))
 
-  param$url <- paste(
-    "https://api.github.com", "repos", param$username, param$repo,
-    "zipball", param$ref, sep = "/")
+  param$url <- paste("https://github.com/", param$username, "/", param$repo,
+    "/archive/", param$ref, ".zip", sep = "")
 
   param
 }
@@ -140,7 +139,7 @@ install_github_single <- function(repo, username = NULL, ref = "master",
 
   # The downloaded file is always named by the package's name with extension .zip.
   # install_github("shiny", "rstudio", "v/0/2/1")
-  #  URL: https://api.github.com/repos/rstudio/shiny/zipball/v/0/2/1
+  #  URL: https://github.com/rstudio/shiny/archive/v/0/2/1.zip
   #  Output file: shiny.zip
   install_url(conn$url, name = paste(conn$repo, ".zip", sep = ""), subdir = conn$subdir,
     config = conn$auth, before_install = github_before_install, ...)

--- a/tests/testthat/test-github.r
+++ b/tests/testthat/test-github.r
@@ -29,12 +29,12 @@ mock_github_ref.github_pull <- function(x, param) {
 
 test_that("GitHub URL is constructed correctly", {
   with_mock("github_ref.github_pull", mock_github_ref.github_pull, {
-    expect_equal(github_get_conn("krlmlr/kimisc")$url, "https://api.github.com/repos/krlmlr/kimisc/zipball/master")
-    expect_equal(github_get_conn("my/test/pkg")$url, "https://api.github.com/repos/my/test/zipball/master")
-    expect_equal(github_get_conn("hadley/devtools@devtools-1.4")$url, "https://api.github.com/repos/hadley/devtools/zipball/devtools-1.4")
-    expect_equal(github_get_conn("yihui/tikzDevice#23")$url, "https://api.github.com/repos/user-23/tikzDevice/zipball/pull-23")
-    expect_equal(github_get_conn("my/test/pkg@ref")$url, "https://api.github.com/repos/my/test/zipball/ref")
-    expect_equal(github_get_conn("my/test/pkg#1")$url, "https://api.github.com/repos/user-1/test/zipball/pull-1")
+    expect_equal(github_get_conn("krlmlr/kimisc")$url, "https://github.com/krlmlr/kimisc/archive/master.zip")
+    expect_equal(github_get_conn("my/test/pkg")$url, "https://github.com/my/test/archive/master.zip")
+    expect_equal(github_get_conn("hadley/devtools@devtools-1.4")$url, "https://github.com/hadley/devtools/archive/devtools-1.4.zip")
+    expect_equal(github_get_conn("yihui/tikzDevice#23")$url, "https://github.com/user-23/tikzDevice/archive/pull-23.zip")
+    expect_equal(github_get_conn("my/test/pkg@ref")$url, "https://github.com/my/test/archive/ref.zip")
+    expect_equal(github_get_conn("my/test/pkg#1")$url, "https://github.com/user-1/test/archive/pull-1.zip")
     expect_error(github_get_conn("hadley/test#6@123")$url, "Invalid GitHub path")
   })
 })


### PR DESCRIPTION
See discussion in #474.
