### PR TITLE
remove file.copy instruction in compile_dll

### DIFF
--- a/R/compile-dll.r
+++ b/R/compile-dll.r
@@ -33,11 +33,6 @@ compile_dll <- function(pkg = ".", quiet = FALSE) {
     args = if (needs_clean(pkg)) "--preclean",
     quiet = quiet)
 
-  dll_name <- paste(pkg$package, .Platform$dynlib.ext, sep = "")
-  from <- file.path("inst", "libs", .Platform$r_arch, dll_name)
-  to <- dll_path(pkg)
-  file.copy(from, to)
-
   invisible(dll_path(pkg))
 }
 


### PR DESCRIPTION
The command was silently failing, but apparently not posing any problem, as pointed by @wch in #513.
So I just removed the `file.copy` command and this patch replaces #513.
