### PR TITLE
Preserve full extension if it contains ".tar"

### DIFF
--- a/R/install-url.r
+++ b/R/install-url.r
@@ -34,7 +34,7 @@ remote_download.url_remote <- function(x, quiet = FALSE) {
     message("Downloading package from url: ", x$url)
   }
 
-  bundle <- tempfile(fileext = paste0(".", tools::file_ext(x$url)))
+  bundle <- tempfile(fileext = paste0(".", file_ext(x$url)))
   download(bundle, x$url, x$config)
 }
 

--- a/R/utils.r
+++ b/R/utils.r
@@ -71,3 +71,12 @@ download <- function(path, url, ...) {
 }
 
 last <- function(x) x[length(x)]
+
+# Modified version of utils::file_ext. Instead of always returning the text
+# after the last '.', as in "foo.tar.gz" => ".gz", if the text that directly
+# precedes the last '.' is ".tar", it will include also, so
+# "foo.tar.gz" => ".tar.gz"
+file_ext <- function (x) {
+    pos <- regexpr("\\.((tar\\.)?[[:alnum:]]+)$", x)
+    ifelse(pos > -1L, substring(x, pos + 1L), "")
+}


### PR DESCRIPTION
This fixes #580.

The new version of `file_ext` now preserves the ".tar" in ".tar.xxx":

``` R
file_ext('foo.tar.gz')
# [1] "tar.gz"
```

Strings other than ".tar" aren't preserved:

``` R
file_ext('foo.ar.gz')
# [1] "gz"
```
