### PR TITLE
Only ignore devtools.Rproj

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -1,4 +1,4 @@
-^.*\.Rproj$
+^devtools\.Rproj$
 ^\.Rproj\.user$
 ^\.travis\.yml$
 ^NEWS.md$

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,10 @@
 # devtools 1.X
 
+## Bug fixes
+
+* The file `template.Rproj` is now correctly installed and the function
+  `use_rstudio` works as it should. (#595, @hmalmedal)
+
 # devtools 1.6
 
 ## Tool templates and `create()`


### PR DESCRIPTION
I installed devtools 1.6 from cran. The file `template.Rproj` wasn't installed, so the function `use_rstudio` didn't work.
