### PR TITLE
Add missing wildcards

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -5,6 +5,9 @@
 * The file `template.Rproj` is now correctly installed and the function
   `use_rstudio` works as it should. (#595, @hmalmedal)
 
+* The function `use_rcpp` will now create the file `src/.gitignore` with the
+  correct wildcards. (@hmalmedal)
+
 # devtools 1.6
 
 ## Tool templates and `create()`

--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -101,7 +101,8 @@ use_rcpp <- function(pkg = ".") {
 
   message("Creating src/ and src/.gitignore")
   dir.create(file.path(pkg$path, "src"), showWarnings = FALSE)
-  union_write(file.path(pkg$path, "src", ".gitignore"), c(".o", ".so", ".dll"))
+  union_write(file.path(pkg$path, "src", ".gitignore"),
+              c("*.o", "*.so", "*.dll"))
 
   message(
     "Next, include the following roxygen tags somewhere in your package:\n",


### PR DESCRIPTION
The function `use_rcpp` creates the file `src/.gitgnore` without correct wildcards.
