### PR TITLE
Support directory traversal to find package root when loading & unloading

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -29,5 +29,6 @@ Suggests:
     Rcpp (>= 0.10.0),
     MASS,
     rmarkdown,
-    knitr
+    knitr,
+    testthatsomemore
 License: GPL (>= 2)

--- a/R/load.r
+++ b/R/load.r
@@ -86,8 +86,12 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
   export_all = TRUE, quiet = FALSE) {
 
   if (!is.package(pkg)) {
-    create_description(pkg)
-    pkg <- as.package(pkg)
+    if (is.in_package(pkg)) {
+      pkg <- as.package(package_root(pkg))
+    } else {
+      create_description(pkg)
+      pkg <- as.package(pkg)
+    }
   }
 
   if (!quiet) message("Loading ", pkg$package)

--- a/R/unload.r
+++ b/R/unload.r
@@ -28,6 +28,7 @@
 #' }
 #' @export
 unload <- function(pkg = ".") {
+  if (is.in_package(pkg)) pkg <- package_root(pkg)
   pkg <- as.package(pkg)
 
   # This is a hack to work around unloading devtools itself. The unloading

--- a/R/utils.r
+++ b/R/utils.r
@@ -73,6 +73,23 @@ download <- function(path, url, ...) {
 
 last <- function(x) x[length(x)]
 
+is.in_package <- function(pkg) {
+  !is.na(package_root(pkg))
+}
+
+package_root <- memoise::memoise(function(path) {
+  if (is.package(path)) return(path$path)
+  else if (!is.character(path)) return(NA_character_)
+  else if (.Platform$OS.type == 'windows')
+    return(NA_character_) # TODO: (RK) Support this, what is dirname(top_level) in Windows?
+
+  has_description <- function(path) file.exists(file.path(path, 'DESCRIPTION'))
+  path <- suppressWarnings(normalizePath(path))
+  while (!has_description(path) && path != '/' && path != '.') path <- dirname(path)
+  if (path == '/') NA_character_
+  else path
+})
+
 # Modified version of utils::file_ext. Instead of always returning the text
 # after the last '.', as in "foo.tar.gz" => ".gz", if the text that directly
 # precedes the last '.' is ".tar", it will include also, so

--- a/tests/testthat/test-load_all.R
+++ b/tests/testthat/test-load_all.R
@@ -1,0 +1,39 @@
+context('load_all')
+library(testthatsomemore)
+
+example_package <- list(
+  DESCRIPTION = 
+"Package: floobit
+Type: Package
+Title: floobit
+Description: floobit bar baz lorem ipsum
+Version: 1.3.3.7
+Authors@R: c(person('Floobit', 'Maker', email = 'floobit@maker.com', role = c('aut','cre')))
+Depends:
+  R (>= 3.0.2)
+License:
+  MIT",
+  NAMESPACE = 'export(floobit_example)',
+  R = list(example.R = "floobit_example <- function(...) 'floobit'")
+)
+
+test_that('it can load a package when not in the root', {
+  within_file_structure(example_package, {
+    load_all(file.path(tempdir, 'R')) # Load from inside R directory instead of package root
+    expect_is(get('floobit_example', envir = asNamespace('floobit')), 'function')
+    unloadNamespace('floobit')
+  })
+})
+
+context('unload')
+
+test_that('it can unload a package when not in the root', {
+  within_file_structure(example_package, {
+    load_all(file.path(tempdir, 'R')) 
+    expect_is(get('floobit_example', envir = asNamespace('floobit')), 'function')
+    unload(file.path(tempdir, 'R'))
+    expect_false(is.element('floobit', loadedNamespaces()))
+  })
+})
+
+


### PR DESCRIPTION
In response [to the following issue](https://github.com/hadley/devtools/issues/614#issuecomment-58573054), I suggest support for loading using `load("some/package/R")` or `load("some/package/inst/tests")` by looking up the directory structure for the DESCRIPTION file -- not having this can get annoying.

I have added two utility functions, `is.in_package` and `package_root`.
- `is.in_package` determines whether a `character` represents a path (after `normalizePath`) that somewhere
   in its file parent chain has a `DESCRIPTION` file.
- `package_root` returns the absolute path of such a parent directory, or `NA_character_` otherwise. For example,
   `package_root('some/package/inst/tests')` is `'/absolute/path/to/some/package'`).

Since the former must be called to use the latter in `load_all` and `unload`, I have wrapped `package_root` with `memoise`. I do not have a Windows system to test on so this feature has no effect on the existing behavior of `load_all` and `unload` on Windows platforms. Should support be added, the convergence of repeated applications of `dirname` should be determined (on Linux it's `'/'` or `'.'`).

I also offer the use of [testthatsomemore](http://github.com/robertzk/testthatsomemore) for the unit tests: it creates a file structure extemporaneously for the package in a temporary directory. If you disagree with this decision (e.g., maybe `tempfile()` is dysfunctional on read-only platforms), I can make a flat structure like the other sample packages in the `tests` directory.
