### PR TITLE
Support directory traversal to find package root

### DIFF
--- a/R/package.r
+++ b/R/package.r
@@ -36,18 +36,30 @@ check_dir <- function(x) {
 }
 
 package_root <- function(path) {
-  if (is.package(path)) return(path$path)
+  if (is.package(path)) {
+    return(path$path)
+  }
   stopifnot(is.character(path))
 
-  has_description <- function(path) file.exists(file.path(path, 'DESCRIPTION'))
-  path <- suppressWarnings(normalizePath(path))
-  while (!has_description(path) && !is_root(path)) path <- dirname(path)
+  has_description <- function(path) {
+    file.exists(file.path(path, 'DESCRIPTION'))
+  } 
+  path <- normalizePath(path, mustWork = FALSE)
+  while (!has_description(path) && !is_root(path)) {
+    path <- dirname(path) 
+  }
 
-  if (is_root(path)) NULL
-  else path
+  if (is_root(path)) {
+    NULL
+  }
+  else {
+    path
+  }
 }
 
-is_root <- function(path) identical(path, dirname(path))
+is_root <- function(path) {
+  identical(path, dirname(path))
+}
 
 normalise_path <- function(x) {
   x <- sub("\\\\+$", "/", x)

--- a/tests/testthat/test-load-hooks.r
+++ b/tests/testthat/test-load-hooks.r
@@ -143,13 +143,3 @@ test_that("onUnload", {
   # Clean up
   rm(".__testLoadHooks__", envir = .GlobalEnv)
 })
-
-test_that("it can load from outside of package root", {
-  expect_false('testHooks' %in% loadedNamespaces())
-  load_all(file.path("testHooks", "R"))
-  expect_true('testHooks' %in% loadedNamespaces())
-  unload(file.path("testHooks", "R"))
-  expect_false('testHooks' %in% loadedNamespaces())
-})
-
-

--- a/tests/testthat/test-package.R
+++ b/tests/testthat/test-package.R
@@ -1,0 +1,10 @@
+context('package')
+
+test_that("it can load from outside of package root", {
+  expect_false('testHooks' %in% loadedNamespaces())
+  load_all(file.path("testHooks", "R"))
+  expect_true('testHooks' %in% loadedNamespaces())
+  unload(file.path("testHooks", "R"))
+  expect_false('testHooks' %in% loadedNamespaces())
+})
+


### PR DESCRIPTION
In response [to the following issue](https://github.com/hadley/devtools/issues/614#issuecomment-58573054), I suggest support for referencing packages using `load_all("some/package/R")` or `load_all("some/package/inst/tests")` (and `document`, `test`, etc.) by traversing up the directory structure for the DESCRIPTION file -- not having this can get annoying.

I have modified `check_dir` in `package.R` and added a `package_root` helper function that returns the absolute path of such a parent directory, or `NA_character_` otherwise. For example, `package_root('some/package/inst/tests')` is `'/absolute/path/to/some/package'`.
