### PR TITLE
Use after_failure not on_failure

### DIFF
--- a/inst/templates/travis.yml
+++ b/inst/templates/travis.yml
@@ -12,7 +12,7 @@ install:
 
 script: ./travis-tool.sh run_tests
 
-on_failure:
+after_failure:
   - ./travis-tool.sh dump_logs
 
 notifications:


### PR DESCRIPTION
Travis documentation wants the key after_failure not on_failure:
http://docs.travis-ci.com/user/build-configuration/

This key has been updated at craigcitro/r-travis:
https://github.com/craigcitro/r-travis/blob/master/sample.travis.yml
