### PR TITLE
Fix issue #623 (related to Collate field, and loadall with S4 classes)

### DIFF
--- a/R/load.r
+++ b/R/load.r
@@ -92,6 +92,14 @@ load_all <- function(pkg = ".", reset = TRUE, recompile = FALSE,
 
   if (!quiet) message("Loading ", pkg$package)
 
+  # Apply any @includes to update the Collate entry in the DESCRIPTION file
+  # Presumes roxygen2::update_collate has been patched
+  # to do nothing if there are no @includes
+  roxygen2::update_collate(pkg$path)
+  # Refresh the pkg structure with any updates to the Collate entry
+  pkg <- as.package(pkg$path)
+
+
   # Reloading devtools is a special case. Normally, objects in the
   # namespace become inaccessible if the namespace is unloaded before the
   # the object has been accessed. This is kind of a hack - using as.list


### PR DESCRIPTION
This proposed change should resolve issue #623.

The additional code proposed for load_all calls `roxygen2::update_collate` to make sure the Collate field in the DESCRIPTION file is up to date with any `@includes` in the package's R directory, before attempting to read and evaluate any of the package's code.  `as.package` is then used to refresh the `pkg` structure (specifically `pkg$collate`) used in load_all to ensure that later steps are aware of and use the up to date Collate information..  

**IMPORTANT**  This pull request should **NOT** be applied until the roxygen issue klutometis/roxygen#302 has been resolved.  (At the time of writing, ie with that roxygen issue unresolved) `roxygen::update_collate` creates a blank Collate field in (to be precise totally removes the Collate field from) the DESCRIPTION file when there are no `@includes` found in the .r files.  Several of the testthats for devtools have exactly that scenario - viz a manually entered Collate field (rather than one generated by roxygen2 via `@includes`) - and the change to their DESCRIPTION files (if `test()` were run on devtools itself) would _permanently_ damage the test.

I have submitted two pull requests for roxygen2, namely pull request klutometis/roxygen#303 (to resolve the roxygen issue), and klutometis/roxygen#304 (to add a testthat the roxygen issue is indeed resolved satisfactorily).  Please review those changes before considering this request.

I will submit a separate pull request containing a testthat issue #623 is actually resolved.

Geoff
