### PR TITLE
Fix build_win() alias to check_win()

### DIFF
--- a/R/check-win.r
+++ b/R/check-win.r
@@ -20,7 +20,7 @@ NULL
 #' @export
 build_win <- function(pkg = ".", version = c("R-devel", "R-release")) {
   .Deprecated("check_win_*()", package = "devtools")
-  check_win(pkg = pkg, version = match.arg(version))
+  check_win(pkg = pkg, version = match.arg(version, several.ok = TRUE))
 }
 
 #' @describeIn check_win Check package on the development version of R.


### PR DESCRIPTION
Also the convention in the tidyverse is to soft-deprecate before deprecating for at least one minor release cycle (i.e. middle number). Should we follow the same convention in r-lib? cc @hadley