### PR TITLE
Adjust to git2r's S4 --> S3 transition

### DIFF
--- a/R/git.R
+++ b/R/git.R
@@ -4,13 +4,13 @@ uses_git <- function(path = ".") {
 
 # sha of most recent commit
 git_repo_sha1 <- function(r) {
-  rev <- git2r::head(r)
+  rev <- utils::head(r)
   if (is.null(rev)) {
     return(NULL)
   }
 
   if (git2r::is_commit(rev)) {
-    rev@sha
+    as.data.frame(rev)$sha
   } else {
     git2r::branch_target(rev)
   }
@@ -31,7 +31,7 @@ git_uncommitted <- function(path = ".") {
 git_sync_status <- function(path = ".", check_ahead = TRUE, check_behind = TRUE) {
   r <- git2r::repository(path, discover = TRUE)
 
-  r_head <- git2r::head(r)
+  r_head <- utils::head(r)
   if (!methods::is(r_head, "git_branch")) {
     stop("HEAD is not a branch", call. = FALSE)
   }
@@ -93,7 +93,8 @@ git_branch <- function(path = ".") {
      return(NULL)
   }
 
-  git2r::head(r)@name
+  ## this `@name` is going to be a problem but it's not an easy fix
+  utils::head(r)@name
 }
 
 # GitHub ------------------------------------------------------------------

--- a/R/release.r
+++ b/R/release.r
@@ -324,7 +324,7 @@ flag_release <- function(pkg = ".") {
 
   date <- Sys.Date()
   commit <- git2r::commits(git2r::init(pkg$path), n = 1)[[1]]
-  sha <- substr(commit@sha, 1, 10)
+  sha <- substr(as.data.frame(commit)$sha, 1, 10)
 
   msg <- paste0(
     "This package was submitted to CRAN on ", date, ".\n",

--- a/tests/testthat/test-git.R
+++ b/tests/testthat/test-git.R
@@ -14,8 +14,8 @@ git_test_repo <- function() {
 test_that("SHA for regular repository", {
   r <- git_test_repo()
   commit <- git2r::commits(r)[[1]]
-  expect_false(git2r::is_commit(git2r::head(r)))
-  expect_equal(git_repo_sha1(r), commit@sha)
+  expect_false(git2r::is_commit(utils::head(r)))
+  expect_equal(git_repo_sha1(r), as.data.frame(commit)$sha)
 })
 
 test_that("SHA for detached head", {
@@ -24,6 +24,6 @@ test_that("SHA for detached head", {
   r <- git_test_repo()
   commit <- git2r::commits(r)[[1]]
   git2r::checkout(commit)
-  expect_true(git2r::is_commit(git2r::head(r)))
-  expect_equal(git_repo_sha1(r), commit@sha)
+  expect_true(git2r::is_commit(utils::head(r)))
+  expect_equal(git_repo_sha1(r), as.data.frame(commit)$sha)
 })


### PR DESCRIPTION
WIP, more to start this conversation

git2r is transitioning from S4 to S3 and I discovered these problems with dev devtools and dev git2r

@stewid do you have any thoughts about packages that were using `@` to access slots in the S4 objects, now that you're returning S3 objects?