### PR TITLE
update minimum foghorn version to ensure compatibility with R >= 3.1

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -42,7 +42,7 @@ Suggests:
     crayon,
     curl (>= 0.9),
     evaluate,
-    foghorn (>= 1.0.0),
+    foghorn (>= 1.0.1),
     gmailr (> 0.7.0),
     knitr,
     lintr (>= 0.2.1),


### PR DESCRIPTION
foghorn 1.0.1 was just accepted on CRAN, and is now compatible with R >= 3.1