### PR TITLE
Enable install_version to install current version of package on Windows/macOS

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.13.3.9000
 
+* `install_version()` can now install current version of CRAN package on Windows
+  and macOS (@jdblischak, #1730)
+
 * The CRAN-RELEASE file is now added to .Rbuildignore (#1711)
 
 * The `lang` argument to `spell_check()` was removed, for compatibility with

--- a/R/install-version.r
+++ b/R/install-version.r
@@ -24,8 +24,7 @@ install_version <- function(package, version = NULL,
   if (package %in% row.names(available)) {
     current.version <- available[package, 'Version']
     if (is.null(version) || version == current.version) {
-      return(install.packages(package, repos = repos, contriburl = contriburl,
-        type = type, ...))
+      return(install.packages(package, repos = repos, type = type, ...))
     }
   }
 


### PR DESCRIPTION
## Motivation and summary

Because of the impending API change in the package git2r, I want to write documentation that advises users to install version 0.21.0 of git2r, which is still the current version of CRAN. This doesn't work with the current version of `devtools::install_version` on Windows or macOS. This PR fixes it.

## The Diaspora

I read about the [diaspora](https://github.com/r-lib/devtools#diaspora). However, I still decided to send the PR here because unlike packages like pkgbuild and usethis, remotes is not yet a dependency for devtools. Also, `remotes::install_version` doesn't have this issue. Please feel free to close it.

**Edit:** I investigated more. The implementation of `remotes::install_version` has substantially changed from the one in devtools, i.e. it doesn't use `install.packages` to determine the download URL. Instead it constructs the URL itself, always specifying the extension [.tar.gz](https://github.com/r-lib/remotes/blob/master/R/install-version.R#L85). Thus this works when installing from source, but breaks if passed `type = "binary"`.

## Demonstration

On macOS (tested on 10.10.5 and 10.10.13) and Windows (tested on 10), `install_version` results in an error when trying to install the current version. Specifying `type = "binary"` fixes it.

```
# Using devtools master branch on macOS
> packageVersion("devtools")
[1] ‘1.13.5.9000’
> devtools::install_version("git2r", "0.21.0")
downloaded 0 bytes

Error in download.file(url, destfile, method, mode = "wb", ...) : 
  cannot download all files
In addition: Warning message:
In download.file(url, destfile, method, mode = "wb", ...) :
  URL 'https://cran.rstudio.com/src/contrib/git2r_0.21.0.tgz': status was '404 Not Found'
Warning in download.packages(pkgs, destdir = tmpd, available = available,  :
  download of package ‘git2r’ failed
> devtools::install_version("git2r", "0.21.0", type = "binary")
trying URL 'https://cran.rstudio.com/bin/macosx/mavericks/contrib/3.3/git2r_0.21.0.tgz'
Content type 'application/x-gzip' length 2212047 bytes (2.1 MB)
==================================================
downloaded 2.1 MB


The downloaded binary packages are in
	/var/folders/5b/hbjnbkkd0t957rs24vxgvw200000gn/T//RtmpVPdqFD/downloaded_packages
```

## Proposed solution

When installing the current version, `install_version` passes everything on to `install.packages`. According to the `install.packages` man page, you are not supposed to set both `contriburl` and `type = "both"`:

> Overrides argument repos. Incompatible with type = "both".

On the Windows and macOS machines I tested, `getOptions("pkgType")` was `"both"`. I was able to fix the problem by removing the manual setting of `contriburl` by `install_version`. This was unnecessary anyways because it was using the same default as `install.packages` does: `contrib.url(repos, type)`.

I confirmed that this solution works on macOS, Windows, and Linux.

Potentially related issues: https://github.com/r-lib/devtools/issues/1724#issuecomment-369339434, https://github.com/r-hub/rhub/issues/123

If this PR is useful, I can add a bullet point to `NEWS.md`.


