### PR TITLE
Require git2r >= 0.21.0.9002.

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -19,7 +19,7 @@ Imports:
     callr,
     cli,
     digest,
-    git2r (>= 0.12.0.9002),
+    git2r (>= 0.21.0.9002),
     httr (>= 0.4),
     jsonlite,
     memoise (>= 1.0.0),


### PR DESCRIPTION
The current version with the S3 methods is [0.21.0.9002](https://github.com/ropensci/git2r/blob/d17df22adeba0340d9d198b03809c571765df6d2/DESCRIPTION#L7).

This is a tiny PR, so I don't think this requires any mention in the NEWS. Please let me know if you feel otherwise.