### PR TITLE
Prohibit winbuilder urls in cran-comments

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools 1.13.3.9000
 
+* `check()` now emits a warning if `cran-comments.md` contains a link to
+  ephemeral `win-builder` results (@hughparsonage)
+
 * `install_version()` can now install current version of CRAN package on Windows
   and macOS (@jdblischak, #1730)
 

--- a/R/release.r
+++ b/R/release.r
@@ -252,7 +252,15 @@ cran_comments <- function(pkg = ".") {
     return(character())
   }
 
-  paste0(readLines(path, warn = FALSE), collapse = "\n")
+  comments <- readLines(path, warn = FALSE)
+  # e.g. https://win-builder.r-project.org/goBi3K29QiuZ/00check.log
+  #  but https://win-builder.r-project.org/ by itself is ok.
+  if (any(grepl("https?://win-builder\\.r-project\\.org/[A-Za-z0-9]", comments))) {
+    warning("Links to win-builder results are ephemeral and so are not permitted in your release.\n",
+            "Remove this link from cran-comments.md and resubmit.\n")
+  }
+
+  paste0(comments, collapse = "\n")
 }
 
 cran_submission_url <- "http://xmpalantir.wu.ac.at/cransubmit/index2.php"

--- a/tests/testthat/test-check.r
+++ b/tests/testthat/test-check.r
@@ -24,3 +24,49 @@ test_that("check with NOTES captured", {
     fixed = TRUE
   )
 })
+
+test_that("check cran-comments", {
+  skip_on_cran()
+
+  # Create pseudo package that only contains
+  # cran-comments.md, first with an ok comment
+  # then with a bad winbuilder link.
+  temp_dir <- tempfile()
+  skip_if(dir.exists(temp_dir))
+  dir.create(temp_dir)
+  my_pkg <- list(path = temp_dir)
+  class(my_pkg) <- "package"
+
+  writeLines(
+    c("This is a package update. The `rcnst` issue has been fixed.",
+      "",
+      "## Test environments",
+      "* local MRAN R 3.4.3",
+      "* ubuntu 14.04 (on travis-ci), R 3.4.3 and dev <https://travis-ci.org/HughParsonage/TeXCheckR>",
+      "* win-builder (dev and release)",
+      "",
+      "## R CMD check results",
+      "",
+      "0 errors | 0 warnings | 0 notes", ""),
+    con = file.path(temp_dir, "cran-comments.md")
+  )
+  expect_null(cran_comments(pkg = my_pkg))
+
+  writeLines(
+    c("This is a package update. The `rcnst` issue has been fixed.",
+      "",
+      "## Test environments",
+      "* local MRAN R 3.4.3",
+      "* ubuntu 14.04 (on travis-ci), R 3.4.3 and dev <https://travis-ci.org/HughParsonage/TeXCheckR>",
+      "* win-builder (dev and release) <https://win-builder.r-project.org/goBi3K29QiuZ/00check.log>",
+      "",
+      "## R CMD check results",
+      "",
+      "0 errors | 0 warnings | 0 notes",
+      ""),
+    con = file.path(temp_dir, "cran-comments.md")
+  )
+  expect_warning(cran_comments(pkg = my_pkg),
+                 regexp = "Links to win-builder results are ephemeral")
+
+})


### PR DESCRIPTION
Since R CMD check doesn't check `cran-comments.md`, but links to the win-builder logs are not permitted in a submission, their presence should be accompanied by a warning in `release()`. 

(Not sure how common this issue is, but I did get pinged by Uwe for this -- then almost made the same mistake next time.)

The R 3.2 error is I believe unrelated to this PR.