### PR TITLE
Add manual = FALSE arg to check_win_xxx()

### DIFF
--- a/R/check-win.r
+++ b/R/check-win.r
@@ -11,6 +11,8 @@
 #'   \code{\link{as.package}} for more information
 #' @param args Any additional arguments to pass to \code{\link[pkgbuild]{build}}
 #' @param quiet If \code{TRUE}, suppresses output.
+#' @param manual If \code{TRUE}, build manual. Required e.g. for dynamic
+#'   documentation using \code{\\}\code{Sexpr{}}.
 #' @export
 #' @family build functions
 #' @name check_win
@@ -25,24 +27,24 @@ build_win <- function(pkg = ".", version = c("R-devel", "R-release")) {
 
 #' @describeIn check_win Check package on the development version of R.
 #' @export
-check_win_devel <- function(pkg = ".", args = NULL, quiet = FALSE) {
-  check_win(pkg = pkg, version = "R-devel", args = args, quiet = quiet)
+check_win_devel <- function(pkg = ".", args = NULL, quiet = FALSE, manual = FALSE) {
+  check_win(pkg = pkg, version = "R-devel", args = args, quiet = quiet, manual = manual)
 }
 
 #' @describeIn check_win Check package on the release version of R.
 #' @export
-check_win_release <- function(pkg = ".", args = NULL, quiet = FALSE) {
-  check_win(pkg = pkg, version = "R-release", args = args, quiet = quiet)
+check_win_release <- function(pkg = ".", args = NULL, quiet = FALSE, manual = FALSE) {
+  check_win(pkg = pkg, version = "R-release", args = args, quiet = quiet, manual = manual)
 }
 
 #' @describeIn check_win Check package on the previous major release version of R.
 #' @export
-check_win_oldrelease <- function(pkg = ".", args = NULL, quiet = FALSE) {
-  check_win(pkg = pkg, version = "R-oldrelease", args = args, quiet = quiet)
+check_win_oldrelease <- function(pkg = ".", args = NULL, quiet = FALSE, manual = FALSE) {
+  check_win(pkg = pkg, version = "R-oldrelease", args = args, quiet = quiet, manual = manual)
 }
 
 check_win <- function(pkg = ".", version = c("R-devel", "R-release", "R-oldrelease"),
-                      args = NULL, quiet = FALSE) {
+                      args = NULL, quiet = FALSE, manual = FALSE) {
 
   pkg <- as.package(pkg)
   version <- match.arg(version, several.ok = TRUE)
@@ -56,7 +58,7 @@ check_win <- function(pkg = ".", version = c("R-devel", "R-release", "R-oldrelea
     }
   }
 
-  built_path <- pkgbuild::build(pkg$path, tempdir(), args = args, quiet = quiet)
+  built_path <- pkgbuild::build(pkg$path, tempdir(), args = args, quiet = quiet, manual = manual)
   on.exit(unlink(built_path))
 
   url <- paste0("ftp://win-builder.r-project.org/", version, "/",

--- a/man/check_win.Rd
+++ b/man/check_win.Rd
@@ -7,11 +7,12 @@
 \alias{check_win_oldrelease}
 \title{Build windows binary package.}
 \usage{
-check_win_devel(pkg = ".", args = NULL, quiet = FALSE)
+check_win_devel(pkg = ".", args = NULL, quiet = FALSE, manual = FALSE)
 
-check_win_release(pkg = ".", args = NULL, quiet = FALSE)
+check_win_release(pkg = ".", args = NULL, quiet = FALSE, manual = FALSE)
 
-check_win_oldrelease(pkg = ".", args = NULL, quiet = FALSE)
+check_win_oldrelease(pkg = ".", args = NULL, quiet = FALSE,
+  manual = FALSE)
 }
 \arguments{
 \item{pkg}{package description, can be path or package name.  See
@@ -20,6 +21,9 @@ check_win_oldrelease(pkg = ".", args = NULL, quiet = FALSE)
 \item{args}{Any additional arguments to pass to \code{\link[pkgbuild]{build}}}
 
 \item{quiet}{If \code{TRUE}, suppresses output.}
+
+\item{manual}{If \code{TRUE}, build manual. Required e.g. for dynamic
+documentation using \code{\\}\code{Sexpr{}}.}
 }
 \description{
 This function works by bundling source package, and then uploading to


### PR DESCRIPTION
Closes #1720.

I have no idea why `check_win()` is exported in `NAMESPACE` but has no `\usage{}`. This is likely to trigger `R CMD check` errors.

I'm regularly using `check_win()`, would be great if it was exported but I'd resort to `:::` if it wasn't ;-)