### PR TITLE
Add `submit_to` method to devtools

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,29 @@
+BSD 3-Clause License
+
+Copyright (c) 2018, Uptake
+All rights reserved.
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+* Redistributions of source code must retain the above copyright notice, this
+  list of conditions and the following disclaimer.
+
+* Redistributions in binary form must reproduce the above copyright notice,
+  this list of conditions and the following disclaimer in the documentation
+  and/or other materials provided with the distribution.
+
+* Neither the name of the copyright holder nor the names of its
+  contributors may be used to endorse or promote products derived from
+  this software without specific prior written permission.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/R/release.r
+++ b/R/release.r
@@ -1,6 +1,6 @@
 #' Release package to CRAN.
 #'
-#' Run automated and manual tests, then ftp to CRAN.
+#' Run automated and manual tests, then post package to CRAN.
 #'
 #' The package release process will:
 #'

--- a/R/release.r
+++ b/R/release.r
@@ -295,11 +295,11 @@ build_cran <- function(pkg, args) {
 }
 
 upload_to <- function(dest, pkg, built_path) {
-    pkg <- as.packge(pkg)
+    pkg <- as.package(pkg)
     maint <- maintainer(pkg)
     body <- list(
         pkg_id = "",
-        name = main$name,
+        name = maint$name,
         email = maint$email,
         uploaded_file = httr::upload_file(built_path, "application/x-gzip"),
         comments = cran_comments(pkg),
@@ -361,4 +361,28 @@ flag_release <- function(pkg = ".") {
   )
   writeLines(msg, file.path(pkg$path, "CRAN-RELEASE"))
   usethis::use_build_ignore("CRAN-RELEASE")
+}
+
+#' Submit a package to a specified location.
+#'
+#' This function is like \code{\link{submit_cran}()} but allows you to specify a
+#' location to submit the package to. It's recommended that you use
+#' \code{\link{release_to}()} rather than this function as it performs more checks
+#' prior to submission.
+#'
+#' @param dest location to submit to as a URL.
+#' @param pkg package description, can be path or package name.  See
+#'   \code{\link{as.package}} for more information
+#'
+#' @export
+submit_to <- function(dest, pkg = ".", args = NULL) {
+  if (yesno("Is your email address ", maintainer(pkg)$email, "?"))
+    return(invisible())
+
+  if (yesno("Ready to submit package to ", dest, "?"))
+    return(invisible())
+
+  pkg <- as.package(pkg)
+  built_path <- build_cran(pkg, args = args)
+  upload_to(dest, pkg, built_path)
 }

--- a/R/release.r
+++ b/R/release.r
@@ -294,23 +294,29 @@ build_cran <- function(pkg, args) {
   built_path
 }
 
+upload_to <- function(dest, pkg, built_path) {
+    pkg <- as.packge(pkg)
+    maint <- maintainer(pkg)
+    body <- list(
+        pkg_id = "",
+        name = main$name,
+        email = maint$email,
+        uploaded_file = httr::upload_file(built_path, "application/x-gzip"),
+        comments = cran_comments(pkg),
+        upload = "Upload package"
+    )
+    resp <- httr::POST(dest, body = body)
+    httr::stop_for_status(resp)
+    resp
+}
+
 upload_cran <- function(pkg, built_path) {
   pkg <- as.package(pkg)
   maint <- maintainer(pkg)
-  comments <- cran_comments(pkg)
 
   # Initial upload ---------
   message("Uploading package & comments")
-  body <- list(
-    pkg_id = "",
-    name = maint$name,
-    email = maint$email,
-    uploaded_file = httr::upload_file(built_path, "application/x-gzip"),
-    comment = comments,
-    upload = "Upload package"
-  )
-  r <- httr::POST(cran_submission_url, body = body)
-  httr::stop_for_status(r)
+  r <- upload_to(cran_submission_url(), pkg, built_path)
   new_url <- httr::parse_url(r$url)
 
   # Confirmation -----------

--- a/R/release.r
+++ b/R/release.r
@@ -312,7 +312,6 @@ upload_cran <- function(pkg, built_path) {
   r <- httr::POST(cran_submission_url, body = body)
   httr::stop_for_status(r)
   new_url <- httr::parse_url(r$url)
-  new_url$query$strErr
 
   # Confirmation -----------
   message("Confirming submission")


### PR DESCRIPTION
Hi!

This PR adds the ability to specify the destination you'd like to release a package to in cases where you'd like to submit to an alternative repository to CRAN (e.g. internal private repositories). In addition, by abstracting away the destination url, it makes the rest of the methods much easier to test without hitting CRAN directly. 

This PR is WIP while I still write tests. I'm opening the PR as a venue for discussing the API. 