### PR TITLE
Add build_package_index to build a proper package index

### DIFF
--- a/R/document.r
+++ b/R/document.r
@@ -45,5 +45,8 @@ document <- function(pkg = ".", clean = NULL, roclets = NULL, reload = TRUE) {
   )
 
   pkgload::dev_topic_index_reset(pkg$package)
+
+  build_package_index(pkg)
+
   invisible()
 }

--- a/R/index.R
+++ b/R/index.R
@@ -1,0 +1,13 @@
+# Makes the package index, so help files and vignettes exist in development
+# packages like they would for an installed package
+build_package_index <- function(pkg) {
+
+  usethis_use_directory(pkg, "Meta", ignore = TRUE)
+  usethis_use_directory(pkg, "help", ignore = TRUE)
+  usethis_use_directory(pkg, "html", ignore = TRUE)
+
+  db <- tools::Rd_db(dir = pkg$path)
+  names(db) <- sub("\\.[Rr]d$", "", basename(as.character(names(db))))
+  ("tools" %:::% "makeLazyLoadDB")(db, file.path("help", pkg$package))
+  ("tools" %:::% ".writePkgIndices")(pkg$path, pkg$path)
+}

--- a/R/usethis.R
+++ b/R/usethis.R
@@ -2,3 +2,10 @@
 
 #' @importFrom withr defer
 local_proj <- withr::local_(usethis::proj_set)
+
+usethis_use_directory <- function(pkg, dir, ignore = FALSE) {
+  capture.output({
+    local_proj(pkg$path)
+    usethis::use_directory(dir, ignore)
+  })
+}


### PR DESCRIPTION
This allows the RStudio help to work for development packages like it
does for installed packages

I am not entirely sure this is a good idea, but it does allow you to view the package index without installing the package, which is useful in RStudio and for finding package vignettes...