### PR TITLE
Ensure that remote_sha.github honours credentials (fixes #1827)

### DIFF
--- a/R/install-github.r
+++ b/R/install-github.r
@@ -274,9 +274,19 @@ remote_package_name.github_remote <- function(remote, url = "https://raw.githubu
 
 #' @export
 remote_sha.github_remote <- function(remote, url = "https://github.com", ...) {
+  
+  # honour credentials if any
+  cred <- if( !is.null(remote$auth_token) ){
+    usr <- remote$auth_user
+    if( is.null(usr) ) usr <- "__anonymous__" # NOTE: an empty string seems to cause git2r::remote_ls to hang
+    git2r::cred_user_pass(usr, remote$auth_token)
+    
+  }
+  
   tryCatch({
     res <- git2r::remote_ls(
       paste0(url, "/", remote$username, "/", remote$repo, ".git"),
+      credentials = cred, 
       ...)
 
     found <- grep(pattern = paste0("\\b", remote$ref), x = names(res), perl = TRUE)


### PR DESCRIPTION
This makes sure that `remote_sha.github` uses `auth_token` when querying the remote repository.