### PR TITLE
Typos fixed in install-gitlab.R file

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -36,7 +36,7 @@
 * `get_path()`, `set_path()`, `add_path()` and `on_path()` have been removed,
   this functionality is available with `withr::with_path()` (#1796).
 
-* `install_cran()` and the CRAN remote now now always downloads the binary if
+* `install_cran()` and the CRAN remote now always downloads the binary if
   one is available (#1724, #1605).
 
 * `release()` gains an additional question ensuring you updated codemeta.json

--- a/R/install-gitlab.r
+++ b/R/install-gitlab.r
@@ -14,7 +14,7 @@
 #' @family package installation
 #' @examples
 #' \dontrun{
-#' install_github("jimhester/covr")
+#' install_gitlab("jimhester/covr")
 #' }
 install_gitlab <- function(repo,
                            auth_token = gitlab_pat(),
@@ -165,7 +165,7 @@ download_gitlab <- function(path, url, ...) {
 
 #' Retrieve Gitlab personal access token.
 #'
-#' A github personal access token
+#' A Gitlab personal access token
 #' Looks in env var \code{GITLAB_PAT}
 #'
 #' @keywords internal

--- a/man/gitlab_pat.Rd
+++ b/man/gitlab_pat.Rd
@@ -7,7 +7,7 @@
 gitlab_pat(quiet = TRUE)
 }
 \description{
-A github personal access token
+A Gitlab personal access token
 Looks in env var \code{GITLAB_PAT}
 }
 \keyword{internal}

--- a/man/install_gitlab.Rd
+++ b/man/install_gitlab.Rd
@@ -32,7 +32,7 @@ not changed since the previous installation.
 }
 \examples{
 \dontrun{
-install_github("jimhester/covr")
+install_gitlab("jimhester/covr")
 }
 }
 \seealso{


### PR DESCRIPTION
'github' entries changed to 'gitlab' in the file `install-gitlab.R` and documentation