### PR TITLE
Rely on roxygen2 more

### DIFF
--- a/R/document.r
+++ b/R/document.r
@@ -20,20 +20,24 @@ document <- function(pkg = ".", roclets = NULL) {
     rstudioapi::documentSaveAll()
   }
 
-  # Refresh the pkg structure with any updates to the Collate entry
-  # in the DESCRIPTION file
-  roxygen2::update_collate(pkg$path)
+  if (packageVersion("roxygen2") >= "6.1.0") {
+    withr::with_envvar(r_env_vars(), roxygen2::roxygenise(pkg$path, roclets))
+  } else {
+    # Refresh the pkg structure with any updates to the Collate entry
+    # in the DESCRIPTION file
+    roxygen2::update_collate(pkg$path)
 
-  roclets <- roclets %||% roxygen2::load_options(pkg$path)$roclets
-  roclets <- setdiff(roclets, "collate")
+    roclets <- roclets %||% roxygen2::load_options(pkg$path)$roclets
+    roclets <- setdiff(roclets, "collate")
 
-  if (packageVersion("roxygen2") < "6.1.0") {
-    load_all(pkg$path, helpers = FALSE)
+    if (packageVersion("roxygen2") < "6.1.0") {
+      load_all(pkg$path, helpers = FALSE)
+    }
+
+    withr::with_envvar(r_env_vars(),
+      roxygen2::roxygenise(pkg$path, roclets = roclets, load_code = pkgload::pkg_ns)
+    )
   }
-
-  withr::with_envvar(r_env_vars(),
-    roxygen2::roxygenise(pkg$path, roclets = roclets, load_code = pkgload::pkg_ns)
-  )
 
   pkgload::dev_topic_index_reset(pkg$package)
   invisible()


### PR DESCRIPTION
Much of the previous code is no longer necessary as roxygen2 handles it internally. Once we can move roxygen2 back into imports, we can add a version dependency there and then delete the old code.