### PR TITLE
Reload loaded packages as well as attached packages

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 1.13.6.9000
 
+* `reload()` now reloads loaded but not attached packages as well as attached ones.
+
 * Executed `styler::style_pkg()` to update code style (#1851, @amundsenjunior).
 
 * All `install_*()` functions are now re-exported from remotes rather than being defined in devtools.

--- a/R/reload.r
+++ b/R/reload.r
@@ -26,8 +26,12 @@ reload <- function(pkg = ".", quiet = FALSE) {
   pkg <- as.package(pkg)
 
   if (is_attached(pkg)) {
-    if (!quiet) message("Reloading installed ", pkg$package)
+    if (!quiet) message("Reloading attached ", pkg$package)
     pkgload::unload(pkg$package)
     require(pkg$package, character.only = TRUE, quietly = TRUE)
+  } else if (is_loaded(pkg)) {
+    if (!quiet) message("Reloading loaded ", pkg$package)
+    pkgload::unload(pkg$package)
+    requireNamespace(pkg$package, character.only = TRUE, quietly = TRUE)
   }
 }


### PR DESCRIPTION
Historically `reload()` only reloaded attached packages, this changes
the behavior to reload packages which are only loaded, not attached as
well.

@wch, @hadley Do either of you remember if there was a reason `reload()` only reloaded attached packages? It seems to me like it should reload loaded, but not attached packages as well.