### PR TITLE
check: pass check_dir to rcmdcheck

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -162,7 +162,6 @@ check_built <- function(path = NULL, cran = TRUE,
 
   pkgname <- gsub("_.*?$", "", basename(path))
 
-  args <- c(paste0("--output=", normalizePath(check_dir)), args)
   if (cran) {
     args <- c("--as-cran", args)
   }
@@ -195,7 +194,8 @@ check_built <- function(path = NULL, cran = TRUE,
   }
 
   withr::with_envvar(env_vars, action = "prefix", {
-    rcmdcheck::rcmdcheck(path, quiet = quiet, args = args, error_on = error_on)
+    rcmdcheck::rcmdcheck(path, quiet = quiet, args = args,
+                         check_dir = check_dir, error_on = error_on)
   })
 }
 


### PR DESCRIPTION
Instead of using the `--output` argument of `R CMD check`.
`--output` is impossible to quote correctly on windows,
because of the processx auto-quoting and/or R's
command line reparsing.

Closes #1864.