### PR TITLE
Bust appveyor cache when the DESCRIPTION file changes

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools 2.0.1.9000 - Development
 
+* Appveyor template busts package cache when the DESCRIPTION file changes (@schloerke, #1961)
+
 * `load_all()` now accepts 'package' objects, regaining previous behavior in
   devtools prior to 2.0.0 (#1923)
 

--- a/inst/templates/appveyor.yml
+++ b/inst/templates/appveyor.yml
@@ -11,7 +11,7 @@ install:
   ps: Bootstrap
 
 cache:
-  - C:\RLibrary
+  - C:\RLibrary -> DESCRIPTION
 
 # Adapt as necessary starting from here
 


### PR DESCRIPTION
Helps when versions are bumped, but the package already exists in the cache.

Link: https://www.appveyor.com/docs/build-cache/#cache-dependencies