### PR TITLE
Fix attaching usethis if lib path has changed

### DIFF
--- a/R/zzz.R
+++ b/R/zzz.R
@@ -68,5 +68,7 @@ devtools_default_options <- list(
 .onAttach <- function(libname, pkgname) {
   env <- as.environment(paste0("package:", pkgname))
   env[[".conflicts.OK"]] <- TRUE
-  suppressPackageStartupMessages((get("library", baseenv()))("usethis"))
+  usethis_lib <- dirname(getNamespaceInfo("usethis", "path"))
+  suppressPackageStartupMessages((
+    get("library", baseenv()))("usethis", lib.loc = usethis_lib))
 }


### PR DESCRIPTION
If the lib path has changed since loading usethis,
.onAttach potentially fails when it tries to attach
usethis as the new lib path might contain a different
usethis version.

Closes #1987.