### PR TITLE
Clearer links to new homes of deprecated functions

### DIFF
--- a/R/infrastructure.R
+++ b/R/infrastructure.R
@@ -1,5 +1,7 @@
 #' @details
-#' Instead of the use_xyz functions from devtools use \link[usethis]{use_testthat}.
+#' Instead of the use_xyz functions from devtools use the same function from
+#' the \href{https://github.com/r-lib/usethis}{usethis} package, for example
+#' \code{usethis::\link[usethis]{use_testthat}}.
 #' @rdname devtools-deprecated
 #' @importFrom usethis use_testthat
 #' @export

--- a/R/revdep.R
+++ b/R/revdep.R
@@ -62,8 +62,8 @@ print.maintainers <- function(x, ...) {
 }
 
 #' @details
-#' Instead of the revdep functions in devtools a better alternative is
-#' \sQuote{revdepcheck::revdep_check()}.
+#' Instead of the revdep functions from devtools use the same function from
+#' the \href{https://github.com/r-lib/revdepcheck}{revdepcheck} package.
 #' @rdname devtools-deprecated
 #' @export
 revdep_check <- function(pkg = ".", recursive = FALSE, ignore = NULL,

--- a/man/devtools-deprecated.Rd
+++ b/man/devtools-deprecated.Rd
@@ -146,9 +146,11 @@ These functions are Deprecated in this release of devtools, they will be
 marked as Defunct and removed in a future version.
 }
 \details{
-Instead of the use_xyz functions from devtools use \link[usethis]{use_testthat}.
+Instead of the use_xyz functions from devtools use the same function from
+the \href{https://github.com/r-lib/usethis}{usethis} package, for example
+\code{usethis::\link[usethis]{use_testthat}}.
 
-Instead of the revdep functions in devtools a better alternative is
-\sQuote{revdepcheck::revdep_check()}.
+Instead of the revdep functions from devtools use the same function from
+the \href{https://github.com/r-lib/revdepcheck}{revdepcheck} package.
 }
 \keyword{internal}


### PR DESCRIPTION
Just a small tweak to the "Details" section of the man page for the deprecated functions, making it easier for the user to follow links to the new home packages for these functions.