### PR TITLE
Report current branch in release()'s git checks

### DIFF
--- a/R/check-git.R
+++ b/R/check-git.R
@@ -10,9 +10,14 @@ git_checks <- function(pkg = ".") {
   pkg <- as.package(pkg)
   cat_rule(paste0("Running Git checks for ", pkg$package))
 
+  git_report_branch(pkg)
   git_check_uncommitted(pkg)
   git_check_sync_status(pkg)
   cat_rule()
+}
+
+git_report_branch <- function(pkg) {
+  cat("Current branch:", git_branch(pkg$path), "\n")
 }
 
 git_check_uncommitted <- function(pkg) {


### PR DESCRIPTION
Closes #2064

Looks like this:

```
── Running Git checks for devtools ─────────────────────────────────────────────────
Current branch: release-report-branch 
Checking uncommitted files... OK
Checking synchronisation with remote branch... OK
────────────────────────────────────────────────────────────────────────────────────
Were Git checks successful?
1: I forget
2: Uhhhh... Maybe?
3: Of course

Selection: 
```