### PR TITLE
fixes bitbucket links for djnavarro/lsr

### DIFF
--- a/vignettes/dependencies.Rmd
+++ b/vignettes/dependencies.Rmd
@@ -64,10 +64,10 @@ Also' section in `?install` for a complete list.
 Remotes: gitlab::jimhester/covr
 
 # Git
-Remotes: git::git@bitbucket.org:dannavarro/lsr-package.git
+Remotes: git::git@bitbucket.org:djnavarro/lsr.git
 
 # Bitbucket
-Remotes: bitbucket::sulab/mygene.r@default, dannavarro/lsr-package
+Remotes: bitbucket::sulab/mygene.r@default, djnavarro/lsr
 
 # Bioconductor
 Remotes: bioc::3.3/SummarizedExperiment#117513, bioc::release/Biobase


### PR DESCRIPTION
There's nothing of substance here: I moved the bitbucket repository previously located at https://bitbucket.org/dannavarro/lsr-package to https://bitbucket.org/djnavarro/lsr. This PR updates the links in the relevant vignette