### PR TITLE
Added add = TRUE For `check_win`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # devtools (development version)
 
+* `check_win_*()` function now resets the email to the original email after execution (@muschellij2, #2152).
 * `test()` now takes `stop_on_failure` as a formal argument (FALSE by default)
   instead of in `...`. Its value is still passed to `testthat::test_dir` as
   before (@infotroph, #2129).

--- a/R/check-win.R
+++ b/R/check-win.R
@@ -82,7 +82,7 @@ check_win <- function(pkg = ".", version = c("R-devel", "R-release", "R-oldrelea
     args = args,
     manual = manual, quiet = quiet, ...
   )
-  on.exit(unlink(built_path))
+  on.exit(unlink(built_path), add = TRUE)
 
   url <- paste0(
     "ftp://win-builder.r-project.org/", version, "/",


### PR DESCRIPTION
Fixing #2152 As per https://github.com/r-lib/devtools/issues/2152#issuecomment-559144986, by adding `add = TRUE` on the `on.exit/on.error` collector.