### PR TITLE
Update build_vignettes doc to follow renaming local -> build

### DIFF
--- a/R/install.R
+++ b/R/install.R
@@ -32,7 +32,7 @@
 #' @param build_vignettes if `TRUE`, will build vignettes. Normally it is
 #'   `build` that's responsible for creating vignettes; this argument makes
 #'   sure vignettes are built even if a build never happens (i.e. because
-#'   `local = TRUE`).
+#'   `build = FALSE`).
 #' @param keep_source If `TRUE` will keep the srcrefs from an installed
 #'   package. This is useful for debugging (especially inside of RStudio).
 #'   It defaults to the option `"keep.source.pkgs"`.

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -50,7 +50,7 @@ to "always". \code{TRUE} and \code{FALSE} are also accepted and correspond to
 \item{build_vignettes}{if \code{TRUE}, will build vignettes. Normally it is
 \code{build} that's responsible for creating vignettes; this argument makes
 sure vignettes are built even if a build never happens (i.e. because
-\code{local = TRUE}).}
+\code{build = FALSE}).}
 
 \item{keep_source}{If \code{TRUE} will keep the srcrefs from an installed
 package. This is useful for debugging (especially inside of RStudio).


### PR DESCRIPTION
It was renamed in https://github.com/r-lib/devtools/commit/c28507106b864ac724bb1d5551dd6066f186daf4#diff-b4729bd8d077a10ed051487dfd8e39ea