### PR TITLE
Update check.Rd

### DIFF
--- a/man/check.Rd
+++ b/man/check.Rd
@@ -17,7 +17,7 @@ check(
   force_suggests = FALSE,
   run_dont_test = FALSE,
   args = "--timings",
-  env_vars = NULL,
+  env_vars = c(NOT_CRAN = "true"),
   quiet = FALSE,
   check_dir = tempdir(),
   cleanup = TRUE,


### PR DESCRIPTION
https://github.com/r-lib/devtools/commit/466300413f87e51abc5b3b4fa86eb859989450cc fixes #2135  by setting `env_vars = c(NOT_CRAN = "true")` by default. Checking it I saw that the documentation doesn't show this yet. I used `roxygen2::roxygenise()` to update documentation but only commited the respective file.