### PR TITLE
Adding addin for document().

### DIFF
--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -12,3 +12,8 @@ Name: Report test coverage for a package
 Description: Calculate and report the test coverage for the current package, using `devtools::test_coverage()`.
 Binding: test_coverage
 Interactive: false
+
+Name: Document a package.
+Description: A wrapper for `roxygen`'s `roxygen2::roxygenize()`
+Binding: document
+Interactive: false


### PR DESCRIPTION
Rstudio can be used to document a package with a keyboard shortcut (CTRL/CMD+ALT+D) and a few settings under Project Options -> Build Tools -> Generate documentation with Roxygen. Unfortunately it is not possible to get it to run `devtools::document()` without any arguments which is useful as it uses the settings (roclets) given in the `DESCRIPTION` file as desired when using `roxygen2` extensions as e.g. https://github.com/mikldk/roxytest.

One solution would be to get this functionality directly in Rstudio, but that seems to be difficult: https://github.com/rstudio/rstudio/issues/5201. 

This simple addin would be a simple way to achieve the same.