### PR TITLE
Fix typo in addins.dcf

### DIFF
--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -13,7 +13,7 @@ Description: Calculate and report the test coverage for the current package, usi
 Binding: test_coverage
 Interactive: false
 
-Name: Document a package.
+Name: Document a package
 Description: A wrapper for `roxygen`'s `roxygen2::roxygenize()`
 Binding: document
 Interactive: false


### PR DESCRIPTION
None of the other `Name`s have a full stop at the end.