### PR TITLE
Clean up test()

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -59,13 +59,13 @@ test <- function(pkg = ".", filter = NULL, stop_on_failure = FALSE, export_all =
 
   env <- new.env(parent = ns_env)
 
-  testthat_args <- list(test_path, filter = filter, env = env, stop_on_failure = stop_on_failure, ... = ...)
-
-  if (packageVersion("testthat") >= "1.0.2.9000") { # 2.0.0
-    testthat_args <- c(testthat_args, load_helpers = FALSE)
-  } else if (packageVersion("testthat") > "1.0.2") {
-    testthat_args <- c(testthat_args, load_helpers = FALSE)
-  }
+  testthat_args <- list(
+    test_path,
+    filter = filter,
+    env = env,
+    stop_on_failure = stop_on_failure,
+    load_helpers = FALSE,
+    ... = ...)
 
   check_dots_used(action = getOption("devtools.ellipsis_action", rlang::warn))
 


### PR DESCRIPTION
to remove version check that is already ensured by `DESCRIPTION`.