### PR TITLE
Redirect callr stderr to stdout

### DIFF
--- a/R/build-manual.R
+++ b/R/build-manual.R
@@ -14,9 +14,9 @@ build_manual <- function(pkg = ".", path = NULL) {
     "--force",
     paste0("--output=", path, "/", name),
     pkg$path
-  ), fail_on_status = TRUE),
+  ), fail_on_status = TRUE, stderr = "2>&1", spinner = FALSE),
   error = function(e) {
-    cat(e$stderr)
+    cat(e$stdout)
     stop("Failed to build manual", call. = FALSE)
   })
 

--- a/R/build-readme.R
+++ b/R/build-readme.R
@@ -33,7 +33,8 @@ build_rmd <- function(files, path = ".", output_options = list(), ..., quiet = T
       function(...) rmarkdown::render(...),
       args = list(input = path, ..., output_options = output_options, quiet = quiet),
       show = TRUE,
-      spinner = FALSE
+      spinner = FALSE,
+      stderr = "2>&1"
     )
   }
 

--- a/R/install.R
+++ b/R/install.R
@@ -100,7 +100,7 @@ install <-
     }
 
     pkgbuild::with_build_tools(required = FALSE,
-      callr::rcmd("INSTALL", c(install_path, opts), echo = !quiet, show = !quiet, fail_on_status = TRUE)
+      callr::rcmd("INSTALL", c(install_path, opts), echo = !quiet, show = !quiet, spinner = FALSE, stderr = "2>&1", fail_on_status = TRUE)
     )
 
     if (reload && was_loaded) {

--- a/R/run-examples.R
+++ b/R/run-examples.R
@@ -42,7 +42,7 @@ run_examples <- function(pkg = ".", start = NULL, show = TRUE, run_donttest = FA
         function() devtools::run_examples(pkg = path, start = start, test = test, run = run, fresh = FALSE),
         list(path = pkg$path, start = start, test = test, run = run)
       ))
-    callr::r(to_run, show = TRUE, spinner = FALSE)
+    callr::r(to_run, show = TRUE, spinner = FALSE, stderr = "2>&1")
     return(invisible())
   }
 

--- a/R/vignettes.R
+++ b/R/vignettes.R
@@ -61,7 +61,8 @@ build_vignettes <- function(pkg = ".",
     build,
     args = list(pkg_path = pkg$path, clean = clean, upgrade = upgrade, quiet = quiet),
     show = !quiet,
-    spinner = FALSE
+    spinner = FALSE,
+    stderr = "2>&1"
   )
 
   # We need to re-run pkgVignettes now that they are built to get the output


### PR DESCRIPTION
To make sure that they are interleaved correctly.
Fixes https://github.com/r-lib/callr/issues/154