### PR TITLE
Build manual

### DIFF
--- a/R/pkgbuild.R
+++ b/R/pkgbuild.R
@@ -2,10 +2,13 @@
 #' @param path Path in which to produce package.  If `NULL`, defaults to
 #'   the parent directory of the package.
 #' @inherit pkgbuild::build
+#' @note The default `manual = FALSE` is not suitable for a CRAN
+#'   submission, which may require `manual = TRUE`.  Even better, use
+#'   [submit_cran()] or [release()].
 #' @param ... Additional arguments passed to [pkgbuild::build].
 #' @export
 build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
-                  manual = TRUE, args = NULL, quiet = FALSE, ...) {
+                  manual = FALSE, args = NULL, quiet = FALSE, ...) {
   save_all()
 
   if (!file.exists(pkg)) {

--- a/R/pkgbuild.R
+++ b/R/pkgbuild.R
@@ -5,7 +5,7 @@
 #' @param ... Additional arguments passed to [pkgbuild::build].
 #' @export
 build <- function(pkg = ".", path = NULL, binary = FALSE, vignettes = TRUE,
-                  manual = FALSE, args = NULL, quiet = FALSE, ...) {
+                  manual = TRUE, args = NULL, quiet = FALSE, ...) {
   save_all()
 
   if (!file.exists(pkg)) {

--- a/man/build.Rd
+++ b/man/build.Rd
@@ -9,7 +9,7 @@ build(
   path = NULL,
   binary = FALSE,
   vignettes = TRUE,
-  manual = TRUE,
+  manual = FALSE,
   args = NULL,
   quiet = FALSE,
   ...
@@ -52,4 +52,9 @@ installed out of the box). If \code{binary = TRUE}, the package will have
 a platform specific extension (e.g. \code{.zip} for windows), and will
 only be installable on the current platform, but no development
 environment is needed.
+}
+\note{
+The default \code{manual = FALSE} is not suitable for a CRAN
+submission, which may require \code{manual = TRUE}.  Even better, use
+\code{\link[=submit_cran]{submit_cran()}} or \code{\link[=release]{release()}}.
 }

--- a/man/build.Rd
+++ b/man/build.Rd
@@ -9,7 +9,7 @@ build(
   path = NULL,
   binary = FALSE,
   vignettes = TRUE,
-  manual = FALSE,
+  manual = TRUE,
   args = NULL,
   quiet = FALSE,
   ...


### PR DESCRIPTION
This simple change fixes the problem in issue #2295 by changing the default to `manual = TRUE`.  The manual is only included when necessary, because `pkgbuild::build` just calls `R CMD build`, which makes the inclusion decision.