### PR TITLE
Check that the email is actually changed in change_maintainer_email()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,7 @@
 # devtools (development version)
 
 * Add a check to `change_maintainer_email()` to assess whether the email is actually changed.
-  If the email is not changed, the code now stops such that an email is not accidentally sent to the wrong recipient.
+  If the email is not changed, the code now stops such that an email is not accidentally sent to the wrong recipient. (@emilsjoerup, #2073)
 
 * `check()` only re-documents if you have a matching version of roxygen2
    (#2263).

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools (development version)
 
+* Add a check to `change_maintainer_email()` to assess whether the email is actually changed.
+  If the email is not changed, the code now stops such that an email is not accidentally sent to the wrong recipient.
+
 * `check()` only re-documents if you have a matching version of roxygen2
    (#2263).
 * `run_examples(fresh = TRUE)` again works without error (#2264)

--- a/R/check-win.R
+++ b/R/check-win.R
@@ -115,6 +115,10 @@ change_maintainer_email <- function(desc, email) {
   aut[is_maintainer]$email <- email
 
   desc$set_authors(aut)
+  ## Check if the email is actually changed before we actually send the email
+  if(!grepl(email, desc$get_maintainer())){
+    stop("Changing maintainer email failed. Possible reason is using both Authors@R and Maintainer fields in the DESCRIPTION file.", call. = FALSE)
+  }
 
   desc$write()
 }

--- a/tests/testthat/test-check.R
+++ b/tests/testthat/test-check.R
@@ -7,3 +7,9 @@ test_that("can determine when to document", {
   ))
   expect_true(can_document(list(roxygennote = packageVersion("roxygen2"))))
 })
+
+test_that("fail instead of sending an email to wrong recipient", {
+  # The testTest package has both Authors@R and Maintainer field - this causes problems in change_maintainer_email().
+  # The function checks if the provided email is actually the one in the maintainer field instead of sending the report to the wrong recipient
+  expect_error(check_win_release(file.path("testTest"), email = "foo@bar.com"))
+})

--- a/tests/testthat/testTest/DESCRIPTION
+++ b/tests/testthat/testTest/DESCRIPTION
@@ -2,7 +2,11 @@ Package: testTest
 Title: Tools to Make Developing R Code Easier
 License: GPL-2
 Description: Package description.
-Author: Hadley <h.wickham@gmail.com>
+Authors@R:
+    c(person(given = "Hadley",
+             family = "Wickham",
+             role = c("aut", "cre"),
+             email = "h.wickham@gmail.com"))
 Maintainer: Hadley <h.wickham@gmail.com>
 Version: 0.1
 Suggests:


### PR DESCRIPTION
Earlier, I was running `check_win_release(email = 'myname@domain.dk')` on a package I am working on. Due to us using both Authors@R and the Maintainer field in our DESCRIPTION file, the report was sent to a different email address. Luckily it was someone I know and it is no problem.

It is bad form to send the reports to unsuspecting people, so I wrote a check for the `change_maintainer_email()` function such that this does not happen again. 

This issue has come up before in #2073 and I suspect that we are not the only people who have errouneously used both authors@R and Maintainer field.

I wrote a unit test for the change, and had to change a DESCRIPTION file or include a new package. I chose to change the testTest package's description file to use both Authors@R and Maintainer. This had no adverse effect on other tests or package checks.