### PR TITLE
Let `build_vignettes` create more specific .gitignore entries

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,7 +9,7 @@ inst/doc
 .httr-oauth
 tests/testthat/infrastructure/
 script.R
-doc
-Meta
+/doc/
+/Meta/
 tests/*/*/.gitignore
 docs/

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools (development version)
 
+* Make the `.gitignore` entries automatically created by `build_vignettes` more
+  specific. (@klmr, #2317)
+
 * Add a check to `change_maintainer_email()` to assess whether the email is actually changed.
   If the email is not changed, the code now stops such that an email is not accidentally sent to the wrong recipient. (@emilsjoerup, #2073)
 

--- a/R/vignette-r.R
+++ b/R/vignette-r.R
@@ -20,7 +20,7 @@ copy_vignettes <- function(pkg, keep_md) {
   pkg <- as.package(pkg)
 
   usethis_use_directory(pkg, "doc", ignore = TRUE)
-  usethis_use_git_ignore(pkg, "doc")
+  usethis_use_git_ignore(pkg, "/doc/")
 
   doc_dir <- file.path(pkg$path, "doc")
 

--- a/R/vignettes.R
+++ b/R/vignettes.R
@@ -78,7 +78,7 @@ build_vignettes <- function(pkg = ".",
 
 create_vignette_index <- function(pkg, vigns) {
   usethis_use_directory(pkg, "Meta", ignore = TRUE)
-  usethis_use_git_ignore(pkg, "Meta")
+  usethis_use_git_ignore(pkg, "/Meta/")
 
   cli::cli_alert_info("Building vignette index")
 

--- a/tests/testthat/test-vignettes.R
+++ b/tests/testthat/test-vignettes.R
@@ -87,3 +87,18 @@ test_that("vignettes built on install", {
   expect_equal(nrow(vigs), 1)
   expect_equal(vigs[3], "new")
 })
+
+test_that(".gitignore updated when building vignettes", {
+  if (!pkgbuild::has_latex()) {
+    skip("pdflatex not available")
+  }
+
+  pkg <- test_path("testVignettes")
+  gitignore <- file.path(pkg, ".gitignore")
+
+  suppressMessages(clean_vignettes(pkg))
+  suppressMessages(build_vignettes(pkg))
+  on.exit(suppressMessages(clean_vignettes(pkg)))
+
+  expect_true(all(c("/Meta/", "/doc/") %in% readLines(gitignore)))
+})


### PR DESCRIPTION
This PR changes the `.gitignore` entries created by `build_vignettes`, from `doc` and `Meta` to `/doc/` and `/Meta/`, to prevent matching nested folders, as per the discussion in the linked issue.

Implements #2317.