### PR TITLE
Re-license as MIT

### DIFF
--- a/.Rbuildignore
+++ b/.Rbuildignore
@@ -16,3 +16,4 @@
 ^script\.R$
 ^pkgdown$
 ^man-roxygen$
+^LICENSE\.md$

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -13,12 +13,9 @@ Authors@R:
              family = "Chang",
              role = "aut"),
       person(given = "RStudio",
-             role = "cph"),
-      person(given = "R Core team",
-             role = "ctb",
-             comment = "Some namespace and vignette code extracted from base R"))
+             role = "cph"))
 Description: Collection of package development tools.
-License: GPL (>= 2)
+License: MIT + file LICENSE
 URL: https://devtools.r-lib.org/, https://github.com/r-lib/devtools
 BugReports: https://github.com/r-lib/devtools/issues
 Depends: 

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,2 @@
+YEAR: 2021
+COPYRIGHT HOLDER: devtools authors

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,0 +1,21 @@
+# MIT License
+
+Copyright (c) 2021 devtools authors
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/man/devtools.Rd
+++ b/man/devtools.Rd
@@ -59,7 +59,6 @@ Authors:
 Other contributors:
 \itemize{
   \item RStudio [copyright holder]
-  \item R Core team (Some namespace and vignette code extracted from base R) [contributor]
 }
 
 }


### PR DESCRIPTION
And remove R Core from authors list since all GPL code from R itself has been removed/rewritten.

Fixes #2326