### PR TITLE
Fix 'folder' argument to `dir_ls`

### DIFF
--- a/R/dev-mode.R
+++ b/R/dev-mode.R
@@ -67,7 +67,7 @@ is_library <- function(path) {
 
   # otherwise check that the directories are compiled R directories -
   # i.e. that they contain a Meta directory
-  dirs <- dir_ls(path, type = "folder")
+  dirs <- dir_ls(path, type = "directory")
 
   has_pkg_dir <- function(path) length(dir_ls(path, regexp = "Meta")) > 0
   help_dirs <- vapply(dirs, has_pkg_dir, logical(1))


### PR DESCRIPTION
Please forgive me if I missed something here; this is my first time
contributing to an R package.

The dev_mode call to `dir_ls` appears to be incorrect, in that it uses
the argument `type = 'folder'`.   I do not know whether this was valid
at some point in the history of `fs::dir_ls`, but it is invalid now:

```
> fs::dir_ls('.', type = 'folder')
Error in match.arg(type, names(directory_entry_types), several.ok = TRUE) :
  'arg' should be one of “any”, “unknown”, “file”, “directory”, “symlink”, “FIFO”, “socket”, “character_device”, “block_device”
> fs::dir_ls('.', type = 'directory')
R           inst        man         man-roxygen pkgdown     revdep
tests       vignettes
```

I hit this bug by a route I now find difficult to reconstruct, but the
relevant error is in:

https://github.com/resampling-stats/resampling-with/runs/2308006707?check_suite_focus=true#step:7:5600