### PR TITLE
Don't open projects with `create()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -4,6 +4,8 @@
 
 * The RStudio addins now use `test_active_file()` and `test_coverage_active_file()` instead of the deprecated `test_file()` and `test_coverage_file()` (#2339)
 
+* `create()` no longer opens projects by default to avoid duplicate projects opened by the RStudio IDE project template (#2347, @malcolmbarrett)
+
 # devtools 2.4.0
 
 ## Breaking changes and deprecated functions

--- a/R/create.R
+++ b/R/create.R
@@ -3,8 +3,9 @@
 #' @param path A path. If it exists, it is used. If it does not exist, it is
 #'   created, provided that the parent path exists.
 #' @param ... Additional arguments passed to [usethis::create_package()]
+#' @inheritParams usethis::create_package
 #' @return The path to the created package, invisibly.
 #' @export
-create <- function(path, ...) {
-  usethis::create_package(path, ...)
+create <- function(path, ..., open = FALSE) {
+  usethis::create_package(path, ..., open = open)
 }

--- a/man/create.Rd
+++ b/man/create.Rd
@@ -4,13 +4,20 @@
 \alias{create}
 \title{Create a package}
 \usage{
-create(path, ...)
+create(path, ..., open = FALSE)
 }
 \arguments{
 \item{path}{A path. If it exists, it is used. If it does not exist, it is
 created, provided that the parent path exists.}
 
 \item{...}{Additional arguments passed to \code{\link[usethis:create_package]{usethis::create_package()}}}
+
+\item{open}{If \code{TRUE}, \link[usethis:proj_activate]{activates} the new project:
+\itemize{
+\item If RStudio desktop, the package is opened in a new session.
+\item If on RStudio server, the current RStudio project is activated.
+\item Otherwise, the working directory and active project is changed.
+}}
 }
 \value{
 The path to the created package, invisibly.


### PR DESCRIPTION
This PR disables `open` by default to avoid the duplicate sessions opened in the RStudio package creation gui

Closes #2346 