### PR TITLE
Execute the addins in interactive mode

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools (development version)
 
+* RStudio addins now run in interactive mode, rather than background mode (@jennybc, #2350)
+
 * `install(upgrade)` now defaults to 'default' rather than 'ask'. This allows you to control the default asking behavior with the `R_REMOTES_UPGRADE` environment variable (#2345)
 
 * `build_readme()` now uses the `path` argument, as designed (#2344)

--- a/R/active.R
+++ b/R/active.R
@@ -8,7 +8,10 @@ find_active_file <- function(arg = "file") {
 find_test_file <- function(path) {
   type <- test_file_type(path)
   if (any(is.na(type))) {
-    rlang::abort(c("Don't know how to find tests for: ", path[is.na(type)]))
+    rlang::abort(c(
+      "Don't know how to find tests associated with the active file:",
+      path[is.na(type)]
+    ))
   }
 
   is_test <- type == "test"

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -1,19 +1,19 @@
 Name: Run a test file
 Description: Run the current test file, using `devtools::test_active_file()`.
 Binding: test_active_file
-Interactive: false
+Interactive: true
 
 Name: Report test coverage for a file
 Description: Calculate and report test coverage for the current test file, using `devtools::test_coverage_active_file()`.
 Binding: test_coverage_active_file
-Interactive: false
+Interactive: true
 
 Name: Report test coverage for a package
 Description: Calculate and report the test coverage for the current package, using `devtools::test_coverage()`.
 Binding: test_coverage
-Interactive: false
+Interactive: true
 
 Name: Document a package
 Description: A wrapper for `roxygen`'s `roxygen2::roxygenize()`
 Binding: document
-Interactive: false
+Interactive: true


### PR DESCRIPTION
I prefer the user experience this offers. I feel better oriented and informed about what command I actually invoked and how things are going.

And even, morally, it seems fitting to use `Interactive: true` for these:

https://rstudio.github.io/rstudioaddins/#execution-modes

> The `Interactive` field within the addin registration describes whether the addin is interactive or non-interactive. It’s important to understand when an addin should be declared as interactive versus non-interactive, as this effects how RStudio will attempt to execute the addin:
>
> * Interactive addins are invoked by emitting a call to their function directly into the R console. For addins that display user-interface (e.g. using a Shiny application) this enables users to stop/interrupt them.
>
> * Non-interactive addins are run in the background and can not be interrupted, so it’s imperative that these addins complete execution quickly. Otherwise, it’s possible that your addin could freeze the user’s R session.
>
> The use case for non-interactive addins is typically simple text insertion or transformation, in which case users would be annoyed if each invocation resulted in code being inserted into the console.