### PR TITLE
New addin for run_examples()

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -8,6 +8,8 @@
 
 * Minor test failure on R 4.2 has been fixed.
 
+* New Rstudio addin for `run_examples()` (#2358)
+
 # devtools 2.4.1
 
 * `build_readme()` now uses the `path` argument, as designed (#2344)

--- a/inst/rstudio/addins.dcf
+++ b/inst/rstudio/addins.dcf
@@ -17,3 +17,8 @@ Name: Document a package
 Description: A wrapper for `roxygen`'s `roxygen2::roxygenize()`
 Binding: document
 Interactive: true
+
+Name: Run examples
+Description: Runs R code in examples using `devtools::run_examples()`
+Binding: run_examples
+Interactive: true


### PR DESCRIPTION
Implementing idea suggested in #2358: An Rstudio addin to run all examples.