### PR TITLE
Put more info into CRAN-SUBMISSION and write it for computers, not humans

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # devtools (development version)
 
-`release()` and `submit_cran()` now record submission details using the Debian Control File format, for better machine-readability. This file now includes package version, in addition to full SHA and a timestamp.
+`release()` and `submit_cran()` now record submission details using the Debian Control File format, for better machine-readability. This file has a new name, CRAN-SUBMISSION (instead of CRAN-RELEASE) and now includes package version, in addition to the full SHA and a timestamp.
 
 # devtools 2.4.2
 

--- a/R/release.R
+++ b/R/release.R
@@ -373,8 +373,8 @@ flag_release <- function(pkg = ".") {
     SHA = sha
   )
 
-  write.dcf(dat, file = path(pkg$path, "CRAN-RELEASE"))
-  usethis::use_build_ignore("CRAN-RELEASE")
+  write.dcf(dat, file = path(pkg$path, "CRAN-SUBMISSION"))
+  usethis::use_build_ignore("CRAN-SUBMISSION")
 }
 
 cran_mirror <- function(repos = getOption("repos")) {


### PR DESCRIPTION
Relates to #2139 and https://github.com/r-lib/usethis/issues/1380

Example of what CRAN-RELEASE looks like with this PR:

```
DCF: TRUE
submitted_to_cran_on: 2021-10-13
version: 2.4.2
SHA: f45c182b3009e29763d790006b58a1415e5ef1ff
```

as opposed to the existing:

```
This package was submitted to CRAN on 2021-10-13.
Once it is accepted, delete this file and tag the release (commit e10658f5).
```