### PR TITLE
`devtools::test()` case when not `interactive()` and testing infrastructure not found

### DIFF
--- a/R/test.R
+++ b/R/test.R
@@ -30,7 +30,7 @@ test <- function(pkg = ".", filter = NULL, stop_on_failure = FALSE, export_all =
       }
     } else {
       cli::cli_alert_danger("No testing infrastructure found.")
-      ui_todo('Setup testing with {ui_code("usethis::use_testthat()")}')
+      ui_todo('Setup testing with {ui_code("usethis::use_testthat()")}.')
     }
     return(invisible())
   }

--- a/R/test.R
+++ b/R/test.R
@@ -23,15 +23,15 @@ test <- function(pkg = ".", filter = NULL, stop_on_failure = FALSE, export_all =
   pkg <- as.package(pkg)
 
   if (!uses_testthat(pkg)) {
-    if (interactive()) {
-      cli::cli_alert_danger("No testing infrastructure found. Create it?")
-      if (utils::menu(c("Yes", "No")) == 1) {
-        usethis_use_testthat(pkg)
-      }
-    } else {
-      cli::cli_alert_danger("No testing infrastructure found.")
+    cli::cli_alert_danger("No testing infrastructure found.")
+    if (!interactive()) {
       ui_todo('Setup testing with {ui_code("usethis::use_testthat()")}.')
+      return(invisible())
     }
+    if (yesno("Create it?")) {
+      return(invisible())
+    }
+    usethis_use_testthat(pkg)
     return(invisible())
   }
 

--- a/R/test.R
+++ b/R/test.R
@@ -22,10 +22,15 @@ test <- function(pkg = ".", filter = NULL, stop_on_failure = FALSE, export_all =
   save_all()
   pkg <- as.package(pkg)
 
-  if (!uses_testthat(pkg) && interactive()) {
-    cli::cli_alert_danger("No testing infrastructure found. Create it?")
-    if (utils::menu(c("Yes", "No")) == 1) {
-      usethis_use_testthat(pkg)
+  if (!uses_testthat(pkg)) {
+    if (interactive()) {
+      cli::cli_alert_danger("No testing infrastructure found. Create it?")
+      if (utils::menu(c("Yes", "No")) == 1) {
+        usethis_use_testthat(pkg)
+      }
+    } else {
+      cli::cli_alert_danger("No testing infrastructure found.")
+      ui_todo('Setup testing with {ui_code("usethis::use_testthat()")}')
     }
     return(invisible())
   }

--- a/R/usethis.R
+++ b/R/usethis.R
@@ -6,7 +6,7 @@
 NULL
 
 usethis_use_testthat <- function(pkg) {
-  usethis::local_project(pkg$path, quiet = TRUE)
+  usethis::local_project(pkg$path, quiet = FALSE)
   usethis::use_testthat()
 }
 


### PR DESCRIPTION
This is related/follow up to https://github.com/rstudio/rstudio/pull/10254

Trying to be mode useful when `devtools::test()` is called from the ide (non interactive) and the testing infratructure is not setup. So that we'd get: 

<img width="415" alt="image" src="https://user-images.githubusercontent.com/2625526/146536171-936cd26a-eff8-411e-81bf-374e178472ad.png">

instead of: 

<img width="823" alt="image" src="https://user-images.githubusercontent.com/2625526/146536459-1589aa55-557c-4055-913e-4949bafdad25.png">

I'm not sure this would need to distinguish between Rstudio ide and other non interactive contexts. 

Perhaps this could be followed up later from the perspective of the ide with ui dialogs that mimic the experience of running `devtools::test()` interactively. 