### PR TITLE
Fix typo in documentation

### DIFF
--- a/R/uninstall.R
+++ b/R/uninstall.R
@@ -1,6 +1,6 @@
 #' Uninstall a local development package.
 #'
-#' Uses `remove.package` to uninstall the package.
+#' Uses `remove.packages` to uninstall the package.
 #' To uninstall a package from a non-default library,
 #' use [withr::with_libpaths()].
 #'

--- a/R/uninstall.R
+++ b/R/uninstall.R
@@ -1,17 +1,15 @@
-#' Uninstall a local development package.
+#' Uninstall a local development package
 #'
-#' Uses `remove.packages` to uninstall the package.
-#' To uninstall a package from a non-default library,
-#' use [withr::with_libpaths()].
+#' Uses `remove.packages()` to uninstall the package. To uninstall a package
+#' from a non-default library, use in combination with [withr::with_libpaths()].
 #'
 #' @inheritParams install
-#' @param unload if `TRUE` (the default), will automatically unload the
-#'   package prior to uninstalling.
+#' @param unload if `TRUE` (the default), ensures the package is unloaded, prior
+#'   to uninstalling.
 #' @inheritParams utils::remove.packages
 #' @export
 #' @family package installation
-#' @seealso [with_debug()] to install packages with debugging flags
-#'   set.
+#' @seealso [with_debug()] to install packages with debugging flags set.
 uninstall <- function(pkg = ".", unload = TRUE, quiet = FALSE, lib = .libPaths()[[1]]) {
   pkg <- as.package(pkg)
 

--- a/man/uninstall.Rd
+++ b/man/uninstall.Rd
@@ -20,7 +20,7 @@ package prior to uninstalling.}
     \code{\link{.libPaths}()}.}
 }
 \description{
-Uses \code{remove.package} to uninstall the package.
+Uses \code{remove.packages} to uninstall the package.
 To uninstall a package from a non-default library,
 use \code{\link[withr:with_libpaths]{withr::with_libpaths()}}.
 }

--- a/man/uninstall.Rd
+++ b/man/uninstall.Rd
@@ -2,7 +2,7 @@
 % Please edit documentation in R/uninstall.R
 \name{uninstall}
 \alias{uninstall}
-\title{Uninstall a local development package.}
+\title{Uninstall a local development package}
 \usage{
 uninstall(pkg = ".", unload = TRUE, quiet = FALSE, lib = .libPaths()[[1]])
 }
@@ -10,8 +10,8 @@ uninstall(pkg = ".", unload = TRUE, quiet = FALSE, lib = .libPaths()[[1]])
 \item{pkg}{The package to use, can be a file path to the package or a
 package object.  See \code{\link[=as.package]{as.package()}} for more information.}
 
-\item{unload}{if \code{TRUE} (the default), will automatically unload the
-package prior to uninstalling.}
+\item{unload}{if \code{TRUE} (the default), ensures the package is unloaded, prior
+to uninstalling.}
 
 \item{quiet}{If \code{TRUE}, suppress output.}
 
@@ -20,13 +20,11 @@ package prior to uninstalling.}
     \code{\link{.libPaths}()}.}
 }
 \description{
-Uses \code{remove.packages} to uninstall the package.
-To uninstall a package from a non-default library,
-use \code{\link[withr:with_libpaths]{withr::with_libpaths()}}.
+Uses \code{remove.packages()} to uninstall the package. To uninstall a package
+from a non-default library, use in combination with \code{\link[withr:with_libpaths]{withr::with_libpaths()}}.
 }
 \seealso{
-\code{\link[=with_debug]{with_debug()}} to install packages with debugging flags
-set.
+\code{\link[=with_debug]{with_debug()}} to install packages with debugging flags set.
 
 Other package installation: 
 \code{\link{install}()}


### PR DESCRIPTION
Documentation for `uninstall()` references the `remove.package()` function, which should be `remove.packages()`.