### PR TITLE
Adjust to new RStudio version numbering

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools (development version)
 
+* `dev_sitrep()` has been updated for the calendar-based version number scheme adopted by the RStudio IDE in September 2021 (#2397, #2410).
+
 # devtools 2.4.3
 
 * New `check_mac_release()` function to check a package using the macOS builder at https://mac.r-project.org/macbuilder/submit.html (#2375)

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -2,13 +2,17 @@
 #' @importFrom memoise memoise
 NULL
 
-check_for_rstudio_updates <- function(os = tolower(Sys.info()[["sysname"]]), version = rstudioapi::getVersion(), in_rstudio = rstudioapi::isAvailable()) {
-
+check_for_rstudio_updates <- function(os = tolower(Sys.info()[["sysname"]]),
+                                      version = rstudioapi::versionInfo()$long_version,
+                                      in_rstudio = rstudioapi::isAvailable()) {
   if (!in_rstudio) {
     return()
   }
 
-  url <- sprintf("https://www.rstudio.org/links/check_for_update?version=%s&os=%s&format=%s", version, os, "kvp")
+  url <- sprintf(
+    "https://www.rstudio.org/links/check_for_update?version=%s&os=%s&format=%s",
+    utils::URLencode(version, reserved = TRUE), os, "kvp"
+  )
 
   tmp <- file_temp()
   on.exit(file_delete(tmp))

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -2,8 +2,16 @@
 #' @importFrom memoise memoise
 NULL
 
+rstudio_version_string <- function() {
+  if (!rstudioapi::isAvailable()) {
+    return(character())
+  }
+  rvi <- rstudioapi::versionInfo()
+  rvi$long_version %||% as.character(rvi$version)
+}
+
 check_for_rstudio_updates <- function(os = tolower(Sys.info()[["sysname"]]),
-                                      version = rstudioapi::versionInfo()$long_version,
+                                      version = rstudio_version_string(),
                                       in_rstudio = rstudioapi::isAvailable()) {
   if (!in_rstudio) {
     return()

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -31,9 +31,9 @@ check_for_rstudio_updates <- function(os = tolower(Sys.info()[["sysname"]]),
     }, error = function(e) FALSE)
   )
   if (!download_ok) {
-    # I'll take silent failure here over dev_sitrep() falling over completely
-    # if this download fails
-    return()
+    return(
+      sprintf("Unable to check for RStudio updates (you're using %s).", version)
+    )
   }
   result <- readLines(tmp, warn = FALSE)
 

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -18,7 +18,7 @@ check_for_rstudio_updates <- function(os = tolower(Sys.info()[["sysname"]]),
   }
 
   url <- sprintf(
-    "https://www.rstudio.org/links/check_for_update?version=%s&os=%s&format=%s",
+    "https://www.rstudio.org/links/check_for_update?version=%s&os=%s&format=%s&manual=true",
     utils::URLencode(version, reserved = TRUE), os, "kvp"
   )
 

--- a/tests/testthat/_snaps/sitrep.md
+++ b/tests/testthat/_snaps/sitrep.md
@@ -1,7 +1,7 @@
 # check_for_rstudio_updates
 
     Code
-      writeLines(check_for_rstudio_updates("mac", "0.0.1", TRUE))
+      writeLines(check_for_rstudio_updates("darwin", "0.0.1", TRUE))
     Output
       RStudio {VERSION} is now available (you're using 0.0.1).
       Download at: https://www.rstudio.com/products/rstudio/download/
@@ -9,7 +9,7 @@
 ---
 
     Code
-      writeLines(check_for_rstudio_updates("mac", "1.4.1717", TRUE))
+      writeLines(check_for_rstudio_updates("windows", "1.4.1717", TRUE))
     Output
       RStudio {VERSION} is now available (you're using 1.4.1717).
       Download at: https://www.rstudio.com/products/rstudio/download/
@@ -17,7 +17,7 @@
 ---
 
     Code
-      writeLines(check_for_rstudio_updates("mac", "2021.09.1+372", TRUE))
+      writeLines(check_for_rstudio_updates("darwin", "2021.09.1+372", TRUE))
     Output
       RStudio {VERSION} is now available (you're using 2021.09.1+372).
       Download at: https://www.rstudio.com/products/rstudio/download/
@@ -25,7 +25,7 @@
 ---
 
     Code
-      writeLines(check_for_rstudio_updates("mac", "2021.09.0-daily+328", TRUE))
+      writeLines(check_for_rstudio_updates("windows", "2021.09.0-daily+328", TRUE))
     Output
       RStudio {VERSION} is now available (you're using 2021.09.0-daily+328).
       Download at: https://www.rstudio.com/products/rstudio/download/

--- a/tests/testthat/_snaps/sitrep.md
+++ b/tests/testthat/_snaps/sitrep.md
@@ -1,6 +1,13 @@
 # check_for_rstudio_updates
 
     Code
+      writeLines(check_for_rstudio_updates("windows", "haha-no-wut", TRUE))
+    Output
+      Unable to check for RStudio updates (you're using haha-no-wut).
+
+---
+
+    Code
       writeLines(check_for_rstudio_updates("darwin", "0.0.1", TRUE))
     Output
       RStudio {VERSION} is now available (you're using 0.0.1).

--- a/tests/testthat/_snaps/sitrep.md
+++ b/tests/testthat/_snaps/sitrep.md
@@ -1,0 +1,32 @@
+# check_for_rstudio_updates
+
+    Code
+      writeLines(check_for_rstudio_updates("mac", "0.0.1", TRUE))
+    Output
+      RStudio {VERSION} is now available (you're using 0.0.1).
+      Download at: https://www.rstudio.com/products/rstudio/download/
+
+---
+
+    Code
+      writeLines(check_for_rstudio_updates("mac", "1.4.1717", TRUE))
+    Output
+      RStudio {VERSION} is now available (you're using 1.4.1717).
+      Download at: https://www.rstudio.com/products/rstudio/download/
+
+---
+
+    Code
+      writeLines(check_for_rstudio_updates("mac", "2021.09.1+372", TRUE))
+    Output
+      RStudio {VERSION} is now available (you're using 2021.09.1+372).
+      Download at: https://www.rstudio.com/products/rstudio/download/
+
+---
+
+    Code
+      writeLines(check_for_rstudio_updates("mac", "2021.09.0-daily+328", TRUE))
+    Output
+      RStudio {VERSION} is now available (you're using 2021.09.0-daily+328).
+      Download at: https://www.rstudio.com/products/rstudio/download/
+

--- a/tests/testthat/test-sitrep.R
+++ b/tests/testthat/test-sitrep.R
@@ -2,11 +2,15 @@ test_that("check_for_rstudio_updates", {
   skip_if_offline()
   skip_on_cran()
 
+  # the IDE ends up calling this with `os = "mac"` on macOS, but we would send
+  # "darwin" in that case, so I test with "darwin"
+  # also mix in some "windows"
+
   # returns nothing rstudio not available
-  expect_null(check_for_rstudio_updates("mac", "1.0.0", FALSE))
+  expect_null(check_for_rstudio_updates("darwin", "1.0.0", FALSE))
 
   # returns nothing if the version is ahead of the current version
-  expect_null(check_for_rstudio_updates("mac", "2030.12.0+123", TRUE))
+  expect_null(check_for_rstudio_updates("windows", "2030.12.0+123", TRUE))
 
   # returns something if the version is behind the current version
   local_edition(3)
@@ -16,13 +20,13 @@ test_that("check_for_rstudio_updates", {
 
   # truly ancient
   expect_snapshot(
-    writeLines(check_for_rstudio_updates("mac", "0.0.1", TRUE)),
+    writeLines(check_for_rstudio_updates("darwin", "0.0.1", TRUE)),
     transform = scrub_current_version
   )
 
   # Juliet Rose, does not have long_version, last before numbering changed
   expect_snapshot(
-    writeLines(check_for_rstudio_updates("mac", "1.4.1717", TRUE)),
+    writeLines(check_for_rstudio_updates("windows", "1.4.1717", TRUE)),
     transform = scrub_current_version
   )
 
@@ -32,13 +36,13 @@ test_that("check_for_rstudio_updates", {
 
   # a superceded preview
   expect_snapshot(
-    writeLines(check_for_rstudio_updates("mac", "2021.09.1+372", TRUE)),
+    writeLines(check_for_rstudio_updates("darwin", "2021.09.1+372", TRUE)),
     transform = scrub_current_version
   )
 
   # a superceded daily
   expect_snapshot(
-    writeLines(check_for_rstudio_updates("mac", "2021.09.0-daily+328", TRUE)),
+    writeLines(check_for_rstudio_updates("windows", "2021.09.0-daily+328", TRUE)),
     transform = scrub_current_version
   )
 })

--- a/tests/testthat/test-sitrep.R
+++ b/tests/testthat/test-sitrep.R
@@ -6,11 +6,39 @@ test_that("check_for_rstudio_updates", {
   expect_null(check_for_rstudio_updates("mac", "1.0.0", FALSE))
 
   # returns nothing if the version is ahead of the current version
-  # THIS NEEDS AN UPDATE
-  # expect_null(check_for_rstudio_updates("mac", "1000.0.0", TRUE))
+  expect_null(check_for_rstudio_updates("mac", "2030.12.0+123", TRUE))
 
   # returns something if the version is behind the current version
-  res <- check_for_rstudio_updates("mac", "0.0.1", TRUE)
-  expect_match(res, "RStudio .* is now available")
-  expect_match(res, "Download at")
+  local_edition(3)
+  scrub_current_version <- function(message) {
+    sub("(?<=^RStudio )[0-9\\.\\+]+", "{VERSION}", message, perl = TRUE)
+  }
+
+  # truly ancient
+  expect_snapshot(
+    writeLines(check_for_rstudio_updates("mac", "0.0.1", TRUE)),
+    transform = scrub_current_version
+  )
+
+  # Juliet Rose, does not have long_version, last before numbering changed
+  expect_snapshot(
+    writeLines(check_for_rstudio_updates("mac", "1.4.1717", TRUE)),
+    transform = scrub_current_version
+  )
+
+  # new scheme, introduced 2021-08
+  # YYYY.MM.<patch>[-(daily|preview)]+<build number>[.pro<pro suffix>]
+  # YYY.MM is th expected date of release for dailies and previews
+
+  # a superceded preview
+  expect_snapshot(
+    writeLines(check_for_rstudio_updates("mac", "2021.09.1+372", TRUE)),
+    transform = scrub_current_version
+  )
+
+  # a superceded daily
+  expect_snapshot(
+    writeLines(check_for_rstudio_updates("mac", "2021.09.0-daily+328", TRUE)),
+    transform = scrub_current_version
+  )
 })

--- a/tests/testthat/test-sitrep.R
+++ b/tests/testthat/test-sitrep.R
@@ -6,9 +6,10 @@ test_that("check_for_rstudio_updates", {
   expect_null(check_for_rstudio_updates("mac", "1.0.0", FALSE))
 
   # returns nothing if the version is ahead of the current version
-  expect_null(check_for_rstudio_updates("mac", "1000.0.0", TRUE))
+  # THIS NEEDS AN UPDATE
+  # expect_null(check_for_rstudio_updates("mac", "1000.0.0", TRUE))
 
-  # returns something if the version is behind of the current version
+  # returns something if the version is behind the current version
   res <- check_for_rstudio_updates("mac", "0.0.1", TRUE)
   expect_match(res, "RStudio .* is now available")
   expect_match(res, "Download at")

--- a/tests/testthat/test-sitrep.R
+++ b/tests/testthat/test-sitrep.R
@@ -12,11 +12,18 @@ test_that("check_for_rstudio_updates", {
   # returns nothing if the version is ahead of the current version
   expect_null(check_for_rstudio_updates("windows", "2030.12.0+123", TRUE))
 
-  # returns something if the version is behind the current version
+  # returns something if ...
   local_edition(3)
   scrub_current_version <- function(message) {
     sub("(?<=^RStudio )[0-9\\.\\+]+", "{VERSION}", message, perl = TRUE)
   }
+
+  # version is not understood by the service
+  expect_snapshot(
+    writeLines(check_for_rstudio_updates("windows", "haha-no-wut", TRUE))
+  )
+
+  # version is behind the current version
 
   # truly ancient
   expect_snapshot(
@@ -34,13 +41,13 @@ test_that("check_for_rstudio_updates", {
   # YYYY.MM.<patch>[-(daily|preview)]+<build number>[.pro<pro suffix>]
   # YYY.MM is th expected date of release for dailies and previews
 
-  # a superceded preview
+  # an out-of-date preview
   expect_snapshot(
     writeLines(check_for_rstudio_updates("darwin", "2021.09.1+372", TRUE)),
     transform = scrub_current_version
   )
 
-  # a superceded daily
+  # an out-of-date daily
   expect_snapshot(
     writeLines(check_for_rstudio_updates("windows", "2021.09.0-daily+328", TRUE)),
     transform = scrub_current_version


### PR DESCRIPTION
Closes #2397

As per @jgutman advice:

* Use the long version number for RStudio, when available. Fall back to shorter version otherwise.
* URL encode the version number.
* Add `manual=true` to the URL we use when checking for updates.

Also makes this helper much less likely to throw an error, even if it does not succeed.