### PR TITLE
Fix redundant `load_all()` call in `devtools::test()`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools (development version)
 
+* `test()` no longer calls `load_all()` twice.
+
 * `aspell_env_var()` does a better job of matching R CMD check behaviour,
   which is only to use `aspell`, not `hunspell` or `ispell` (#2376).
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,7 @@
 # devtools (development version)
 
-* `test()` no longer calls `load_all()` twice.
+* `test()` no longer calls `load_all()` twice. `test_active_file()`
+  now calls `load_all()` via testthat.
 
 * `aspell_env_var()` does a better job of matching R CMD check behaviour,
   which is only to use `aspell`, not `hunspell` or `ispell` (#2376).

--- a/R/test.R
+++ b/R/test.R
@@ -35,7 +35,7 @@ test <- function(pkg = ".", filter = NULL, stop_on_failure = FALSE, export_all =
     return(invisible())
   }
 
-  cli::cli_inform(c(i = "Testing {.pkg {pkg$package}}"))
+  cli::cli_inform(c(i = "Testing {.pkg {pkg$package}}."))
   withr::local_envvar(r_env_vars())
   testthat::test_local(
     pkg$path,

--- a/R/test.R
+++ b/R/test.R
@@ -35,8 +35,6 @@ test <- function(pkg = ".", filter = NULL, stop_on_failure = FALSE, export_all =
     return(invisible())
   }
 
-  load_all(pkg$path)
-
   cli::cli_inform(c(i = "Testing {.pkg {pkg$package}}"))
   withr::local_envvar(r_env_vars())
   testthat::test_local(
@@ -62,8 +60,7 @@ test_active_file <- function(file = find_active_file(), ...) {
   pkg <- as.package(path_dir(test_files)[[1]])
 
   withr::local_envvar(r_env_vars())
-  load_all(pkg$path, quiet = TRUE)
-  testthat::test_file(test_files, ...)
+  testthat::test_file(test_files, ..., load_package = "source")
 }
 
 #' @param show_report Show the test coverage report.

--- a/R/test.R
+++ b/R/test.R
@@ -35,7 +35,7 @@ test <- function(pkg = ".", filter = NULL, stop_on_failure = FALSE, export_all =
     return(invisible())
   }
 
-  cli::cli_inform(c(i = "Testing {.pkg {pkg$package}}."))
+  cli::cli_inform(c(i = "Testing {.pkg {pkg$package}}"))
   withr::local_envvar(r_env_vars())
   testthat::test_local(
     pkg$path,


### PR DESCRIPTION
Currently I'm seeing:

```
> devtools::test('~/Sync/Projects/R/r-lib/rlang')
ℹ Loading rlang.
ℹ Testing rlang
ℹ Loading rlang.
```

With this PR this becomes:

```
> devtools::test('~/Sync/Projects/R/r-lib/rlang')
ℹ Testing rlang.
ℹ Loading rlang.
```