### PR TITLE
Use same default as rcmdcheck itself

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,8 @@
 # devtools (development version)
 
+* `check(check_dir = NULL)` is the new default, to align with the default
+  behaviour of the underlying `rcmdcheck::rcmdcheck()`.
+
 * `check(cleanup =)` was deprecated in devtools v1.11.0 (2016-04-12) and was
   made defunct in v2.4.4 (2022-07-20). The documentation is more clear now about
   recommended alternatives.

--- a/R/check.R
+++ b/R/check.R
@@ -65,7 +65,7 @@ check <- function(pkg = ".",
                   args = "--timings",
                   env_vars = c(NOT_CRAN = "true"),
                   quiet = FALSE,
-                  check_dir = tempdir(),
+                  check_dir = NULL,
                   cleanup = deprecated(),
                   vignettes = TRUE,
                   error_on = c("never", "error", "warning", "note")) {

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -19,7 +19,7 @@ check(
   args = "--timings",
   env_vars = c(NOT_CRAN = "true"),
   quiet = FALSE,
-  check_dir = tempdir(),
+  check_dir = NULL,
   cleanup = deprecated(),
   vignettes = TRUE,
   error_on = c("never", "error", "warning", "note")


### PR DESCRIPTION
Related to #2448 and https://github.com/r-lib/rcmdcheck/pull/185

I think devtools should do less: just accept the behaviour and docs around `check_dir` from rcmdcheck.