### PR TITLE
Surface unused imports with `check(cran = TRUE)`

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,11 @@
 # devtools (development version)
 
+* `check(cran = TRUE)` sets the env var
+  `_R_CHECK_PACKAGES_USED_IGNORE_UNUSED_IMPORTS_` to `FALSE`, in order to
+  surface the `"Namespace in Imports field not imported from"` NOTE. This only
+  applies to R >= 4.2, due to favorable changes in the behaviour of
+  `R CMD check --as-cran` (#2459).
+
 * `check(check_dir = NULL)` is the new default, to align with the default
   behaviour of the underlying `rcmdcheck::rcmdcheck()`.
 

--- a/R/check.R
+++ b/R/check.R
@@ -159,7 +159,9 @@ can_document <- function(pkg) {
 #' @rdname check
 #' @param path Path to built package.
 #' @param cran if `TRUE` (the default), check using the same settings as CRAN
-#'   uses.
+#'   uses. Because this is a moving target and is not uniform across all of
+#'   CRAN's machine, this is on a "best effort" basis. It is more complicated
+#'   than simply setting `--as-cran`.
 #' @param remote Sets `_R_CHECK_CRAN_INCOMING_REMOTE_` env var. If `TRUE`,
 #'   performs a number of CRAN incoming checks that require remote access.
 #' @param incoming Sets `_R_CHECK_CRAN_INCOMING_` env var. If `TRUE`, performs a
@@ -188,6 +190,10 @@ check_built <- function(path = NULL, cran = TRUE,
 
   if (cran) {
     args <- c("--as-cran", args)
+    env_vars <- c(
+      "_R_CHECK_PACKAGES_USED_IGNORE_UNUSED_IMPORTS_" = as.character(FALSE),
+      env_vars
+    )
   }
   if (run_dont_test) {
     args <- c("--run-donttest", args)

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -55,7 +55,9 @@ file. Use \code{TRUE} or \code{FALSE} to override the default.}
 \item{manual}{If \code{FALSE}, don't build and check manual (\code{--no-manual}).}
 
 \item{cran}{if \code{TRUE} (the default), check using the same settings as CRAN
-uses.}
+uses. Because this is a moving target and is not uniform across all of
+CRAN's machine, this is on a "best effort" basis. It is more complicated
+than simply setting \code{--as-cran}.}
 
 \item{remote}{Sets \verb{_R_CHECK_CRAN_INCOMING_REMOTE_} env var. If \code{TRUE},
 performs a number of CRAN incoming checks that require remote access.}


### PR DESCRIPTION
Closes #2459 (for R >= 4.2), which seems like a improvement worth having

~Logically, this seems like it should close #2459 and yet I don't think it does? My local R version is not ideal for this at the moment, so I'm going to come back to this when I can experiment with it more easily.~ *I'm on R 4.2 and yes this does what we want.*