### PR TITLE
Deprecate dev_mode()

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -66,5 +66,5 @@ Config/Needs/website: tidyverse/tidytemplate
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.2.1
+RoxygenNote: 7.2.3
 Config/testthat/edition: 3

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,7 +18,7 @@
 
 * `test()` and `test_active_file()` once again work with testthat itself.
 
-* `dev_mode()` is deprecated (#2467).
+* `dev_mode()` is deprecated (@billdenney, #2467).
 
 # devtools 2.4.4
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -18,6 +18,8 @@
 
 * `test()` and `test_active_file()` once again work with testthat itself.
 
+* `dev_mode()` is deprecated (#2467).
+
 # devtools 2.4.4
 
 * `install(reload = TRUE)` now calls `pkgload::unregister()` instead

--- a/R/dev-mode.R
+++ b/R/dev-mode.R
@@ -1,16 +1,25 @@
-#' Activate and deactivate development mode.
+#' Activate and deactivate development mode
 #'
+#' @description
 #' `r lifecycle::badge("deprecated")`
 #'
-#' When activated, `dev_mode` creates a new library for storing installed
-#' packages. This new library is automatically created when `dev_mode` is
-#' activated if it does not already exist.
-#' This allows you to test development packages in a sandbox, without
-#' interfering with the other packages you have installed.
+
+#' We no longer recommend `dev_mode()` and it will be removed in a future
+#' release of devtools. Instead, we now rely on [load_all()] to test drive an
+#' in-development package. If you really like the idea of corralling
+#' experimental packages in a special library, you might enjoy
+#' `withr::local_libpaths()`. If you are concerned about different projects
+#' interfering with each other through the use of a shared library, consider
+#' using the [renv package](https://rstudio.github.io/renv/).
 #'
-#' @param on turn dev mode on (`TRUE`) or off (`FALSE`).  If omitted
-#'  will guess based on whether or not `path` is in
-#'  [.libPaths()]
+#' Original description: When activated, `dev_mode` creates a new library for
+#' storing installed packages. This new library is automatically created when
+#' `dev_mode` is activated if it does not already exist. This allows you to test
+#' development packages in a sandbox, without interfering with the other
+#' packages you have installed.
+#'
+#' @param on turn dev mode on (`TRUE`) or off (`FALSE`).  If omitted will guess
+#'   based on whether or not `path` is in [.libPaths()]
 #' @param path directory to library.
 #' @export
 #' @keywords internal

--- a/R/dev-mode.R
+++ b/R/dev-mode.R
@@ -1,5 +1,7 @@
 #' Activate and deactivate development mode.
 #'
+#' `r lifecycle::badge("deprecated")`
+#'
 #' When activated, `dev_mode` creates a new library for storing installed
 #' packages. This new library is automatically created when `dev_mode` is
 #' activated if it does not already exist.
@@ -11,6 +13,7 @@
 #'  [.libPaths()]
 #' @param path directory to library.
 #' @export
+#' @keywords internal
 #' @examples
 #' \dontrun{
 #' dev_mode()
@@ -20,6 +23,7 @@ dev_mode <- local({
   .prompt <- NULL
 
   function(on = NULL, path = getOption("devtools.path")) {
+    lifecycle::deprecate_warn("2.4.5", "dev_mode()")
     lib_paths <- .libPaths()
 
     path <- path_real(path)

--- a/R/devtools-package.R
+++ b/R/devtools-package.R
@@ -1,17 +1,10 @@
 #' @section Package options:
 #'
 #' Devtools uses the following [options()] to configure behaviour:
-#'
-#' \itemize{
-#'   \item `devtools.path`: path to use for [dev_mode()]; note that `dev_mode()`
-#'     is deprecated.
-#'
-#'   \item `devtools.name`: your name, used when signing draft
-#'     emails.
-#'
-#'   \item `devtools.install.args`: a string giving extra arguments passed
-#'     to `R CMD install` by [install()].
-#' }
+#' * `devtools.install.args`: a string giving extra arguments passed to
+#'   `R CMD install` by [install()].
+#' * `devtools.path`: Deprecated. Path used by the now-deprecated [dev_mode()]
+#'   function.
 #' @docType package
 #' @keywords internal
 "_PACKAGE"

--- a/R/devtools-package.R
+++ b/R/devtools-package.R
@@ -3,7 +3,8 @@
 #' Devtools uses the following [options()] to configure behaviour:
 #'
 #' \itemize{
-#'   \item `devtools.path`: path to use for [dev_mode()]
+#'   \item `devtools.path`: path to use for [dev_mode()]; note that `dev_mode()`
+#'     is deprecated.
 #'
 #'   \item `devtools.name`: your name, used when signing draft
 #'     emails.

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -36,7 +36,6 @@ reference:
     contents:
     - bash
     - clean_vignettes
-    - dev_mode
     - dev_sitrep
     - github_pull
     - lint

--- a/man/dev_mode.Rd
+++ b/man/dev_mode.Rd
@@ -2,26 +2,32 @@
 % Please edit documentation in R/dev-mode.R
 \name{dev_mode}
 \alias{dev_mode}
-\title{Activate and deactivate development mode.}
+\title{Activate and deactivate development mode}
 \usage{
 dev_mode(on = NULL, path = getOption("devtools.path"))
 }
 \arguments{
-\item{on}{turn dev mode on (\code{TRUE}) or off (\code{FALSE}).  If omitted
-will guess based on whether or not \code{path} is in
-\code{\link[=.libPaths]{.libPaths()}}}
+\item{on}{turn dev mode on (\code{TRUE}) or off (\code{FALSE}).  If omitted will guess
+based on whether or not \code{path} is in \code{\link[=.libPaths]{.libPaths()}}}
 
 \item{path}{directory to library.}
 }
 \description{
 \ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
-}
-\details{
-When activated, \code{dev_mode} creates a new library for storing installed
-packages. This new library is automatically created when \code{dev_mode} is
-activated if it does not already exist.
-This allows you to test development packages in a sandbox, without
-interfering with the other packages you have installed.
+
+We no longer recommend \code{dev_mode()} and it will be removed in a future
+release of devtools. Instead, we now rely on \code{\link[=load_all]{load_all()}} to test drive an
+in-development package. If you really like the idea of corralling
+experimental packages in a special library, you might enjoy
+\code{withr::local_libpaths()}. If you are concerned about different projects
+interfering with each other through the use of a shared library, consider
+using the \href{https://rstudio.github.io/renv/}{renv package}.
+
+Original description: When activated, \code{dev_mode} creates a new library for
+storing installed packages. This new library is automatically created when
+\code{dev_mode} is activated if it does not already exist. This allows you to test
+development packages in a sandbox, without interfering with the other
+packages you have installed.
 }
 \examples{
 \dontrun{

--- a/man/dev_mode.Rd
+++ b/man/dev_mode.Rd
@@ -14,6 +14,9 @@ will guess based on whether or not \code{path} is in
 \item{path}{directory to library.}
 }
 \description{
+\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}}
+}
+\details{
 When activated, \code{dev_mode} creates a new library for storing installed
 packages. This new library is automatically created when \code{dev_mode} is
 activated if it does not already exist.
@@ -26,3 +29,4 @@ dev_mode()
 dev_mode()
 }
 }
+\keyword{internal}

--- a/man/devtools-package.Rd
+++ b/man/devtools-package.Rd
@@ -12,16 +12,11 @@ Collection of package development tools.
 
 
 Devtools uses the following \code{\link[=options]{options()}} to configure behaviour:
-
 \itemize{
-\item \code{devtools.path}: path to use for \code{\link[=dev_mode]{dev_mode()}}; note that \code{dev_mode()}
-is deprecated.
-
-\item \code{devtools.name}: your name, used when signing draft
-emails.
-
-\item \code{devtools.install.args}: a string giving extra arguments passed
-to \verb{R CMD install} by \code{\link[=install]{install()}}.
+\item \code{devtools.install.args}: a string giving extra arguments passed to
+\verb{R CMD install} by \code{\link[=install]{install()}}.
+\item \code{devtools.path}: Deprecated. Path used by the now-deprecated \code{\link[=dev_mode]{dev_mode()}}
+function.
 }
 }
 

--- a/man/devtools-package.Rd
+++ b/man/devtools-package.Rd
@@ -14,7 +14,8 @@ Collection of package development tools.
 Devtools uses the following \code{\link[=options]{options()}} to configure behaviour:
 
 \itemize{
-\item \code{devtools.path}: path to use for \code{\link[=dev_mode]{dev_mode()}}
+\item \code{devtools.path}: path to use for \code{\link[=dev_mode]{dev_mode()}}; note that \code{dev_mode()}
+is deprecated.
 
 \item \code{devtools.name}: your name, used when signing draft
 emails.


### PR DESCRIPTION
As indicated in #2467, `dev_mode()` is no longer recommended or receiving fixes.  This PR provides documentation so that users know to migrate away from using it.