### PR TITLE
fix typos

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -907,7 +907,7 @@ There were a handful of smaller fixes:
   (#995, @kevinushey)
 
 * `check(cran = TRUE)` adds `--run-donttest` since you do need to test
-  code in `\dontest()` for CRAN submission (#1002).
+  code in `\donttest()` for CRAN submission (#1002).
 
 ## Package installation
 
@@ -939,7 +939,7 @@ There were a handful of smaller fixes:
 
 * `check_man()` replaces `check_doc()` (since most other functions are
   named after the corresponding directory). `check_doc()` will hang around
-  as an alias for the forseeable future (#958).
+  as an alias for the foreseeable future (#958).
 
 * `create()` produces a dummy namespace will fake comment so roxygen2 will 
   overwrite silently (#1016).

--- a/inst/WORDLIST
+++ b/inst/WORDLIST
@@ -85,7 +85,7 @@ et
 fieldnames
 focussed
 forkable
-forseeable
+foreseeable
 fs
 funder
 gcc


### PR DESCRIPTION
~`https://github.com/r-lib/devtools/issues/2516`~

Closes #2516

NEWS.md
inst/WORDLIST