### PR TITLE
fix documentation of default values for `on_error` parameter

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -50,6 +50,14 @@
 #' @param vignettes If `FALSE`, do not build or check vignettes, equivalent to
 #'   using `args = '--ignore-vignettes' and `build_args = '--no-build-vignettes'.
 #' @param cleanup `r lifecycle::badge("deprecated")` See `check_dir` for details.
+#' @param error_on Whether to throw an error on `R CMD check` failures.
+#'   Note that the check is always completed (unless a timeout happens),
+#'   and the error is only thrown after completion. If `"never"`, then
+#'   no errors are thrown. If `"error"`, then only `ERROR` failures
+#'   generate errors. If `"warning"`, then `WARNING` failures generate
+#'   errors as well. If `"note"`, then any check failure generated an
+#'   error. The default is `"never"` for interactive sessions and `"warning"`
+#'   for non-interactive session.
 #' @seealso [release()] if you want to send the checked package to
 #'   CRAN.
 #' @export

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -100,8 +100,8 @@ and the error is only thrown after completion. If \code{"never"}, then
 no errors are thrown. If \code{"error"}, then only \code{ERROR} failures
 generate errors. If \code{"warning"}, then \code{WARNING} failures generate
 errors as well. If \code{"note"}, then any check failure generated an
-error. Its default can be modified with the \code{RCMDCHECK_ERROR_ON}
-environment variable. If that is not set, then \code{"never"} is used.}
+error. The default is \code{"never"} for interactive sessions and \code{"warning"}
+for non-interactive session.}
 
 \item{path}{Path to built package.}
 }


### PR DESCRIPTION
Currently the documentation for `devtools::check`'s `on_error` parameter reads as inherited from `rcmdcheck::rcmdcheck`:

>Whether to throw an error on R CMD check failures. Note that the check is always completed (unless a timeout happens), and the error is only thrown after completion. If "never", then no errors are thrown. If "error", then only ERROR failures generate errors. If "warning", then WARNING failures generate errors as well. If "note", then any check failure generated an error. **Its default can be modified with the RCMDCHECK_ERROR_ON environment variable. If that is not set, then "never" is used.**

However, `devtools` already sets the default to `"never"` (for interactive session) or `"warning"` (for non-nteractive sessions) according to:
https://github.com/r-lib/devtools/blob/2c642ab44f4fb9d4117f0e198dfcf42ad79e432a/R/check.R#L56
https://github.com/r-lib/devtools/blob/2c642ab44f4fb9d4117f0e198dfcf42ad79e432a/R/check.R#L72
https://github.com/r-lib/devtools/blob/2c642ab44f4fb9d4117f0e198dfcf42ad79e432a/R/check.R#L82-L85

This PR copies the description to of `on_error` to  `devtools::check` and fixes the description of this default behavior.