### PR TITLE
Update cover image in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,7 +87,7 @@ look in the current working directory - this is a recommended practice.
 R package development can be intimidating, however there are now a number of
 valuable resources to help!
 
-<a href="https://r-pkgs.org"><img src="http://r-pkgs.org/images/cover.png" height="252" align = "right" alt="Cover image of R Packages book"/></a>
+<a href="https://r-pkgs.org"><img src="http://r-pkgs.org/images/cover-2e-small.png" height="252" align = "right" alt="Cover image of R Packages book"/></a>
 
 1. R Packages is a book that gives a comprehensive treatment of all common parts
    of package development and uses devtools throughout.


### PR DESCRIPTION
The cover image wasn't showing in the `Learning More` section of the ReadMe:
<img width="918" alt="image" src="https://github.com/r-lib/devtools/assets/8650931/60d29746-40da-4fc6-a43a-294247f42dce">


This should fix it:
<img width="918" alt="image" src="https://github.com/r-lib/devtools/assets/8650931/a871d87a-b3b9-470b-ae3d-d4f7a3e1fc38">

