### PR TITLE
#2545 Added pkgload::run_example() to the documentation for devtools::run_examples().

### DIFF
--- a/R/run-examples.R
+++ b/R/run-examples.R
@@ -11,7 +11,8 @@
 #'   name of `Rd` file to start with (with or without extensions), or
 #'   a topic name. If omitted, will start with the (lexicographically) first
 #'   file. This is useful if you have a lot of examples and don't want to
-#'   rerun them every time you fix a problem.
+#'   rerun them every time you fix a problem. To run only one example, use
+#'   [pkgload::run_example()].
 #' @family example functions
 #' @param show DEPRECATED.
 #' @param fresh if `TRUE`, will be run in a fresh R session. This has
@@ -21,6 +22,8 @@
 #' @param document if `TRUE`, [document()] will be run to ensure
 #'   examples are updated before running them.
 #' @keywords programming
+#'
+#' @seealso [pkgload::run_example()] to run a single example.
 #' @export
 run_examples <- function(pkg = ".", start = NULL, show = deprecated(), run_donttest = FALSE,
                          run_dontrun = FALSE, fresh = FALSE, document = TRUE,

--- a/man/run_examples.Rd
+++ b/man/run_examples.Rd
@@ -24,7 +24,8 @@ package object.  See \code{\link[=as.package]{as.package()}} for more informatio
 name of \code{Rd} file to start with (with or without extensions), or
 a topic name. If omitted, will start with the (lexicographically) first
 file. This is useful if you have a lot of examples and don't want to
-rerun them every time you fix a problem.}
+rerun them every time you fix a problem. To run only one example, use
+\code{\link[pkgload:dev_example]{pkgload::run_example()}}.}
 
 \item{show}{DEPRECATED.}
 
@@ -47,6 +48,9 @@ One of the most frustrating parts of \verb{R CMD check} is getting all of your
 examples to pass - whenever one fails you need to fix the problem and then
 restart the whole process.  This function makes it a little easier by
 making it possible to run all examples from an R function.
+}
+\seealso{
+\code{\link[pkgload:dev_example]{pkgload::run_example()}} to run a single example.
 }
 \concept{example functions}
 \keyword{programming}


### PR DESCRIPTION
Addresses first part of request #2545:
* Added `pkgload::run_example()` to the documentation for `devtools::run_examples()`.