### PR TITLE
Use `purrr::walk()` to yield better error message with `run_examples()`

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -28,6 +28,7 @@ Imports:
     pkgdown (>= 2.0.6),
     pkgload (>= 1.3.0),
     profvis (>= 0.3.7),
+    purrr (>= 1.0.0),
     rcmdcheck (>= 1.4.0),
     remotes (>= 2.4.2),
     rlang (>= 1.0.4),

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -63,8 +63,6 @@ Suggests:
     spelling (>= 2.2)
 VignetteBuilder: 
     knitr
-Remotes: 
-    r-lib/testthat
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
 Encoding: UTF-8

--- a/R/run-examples.R
+++ b/R/run-examples.R
@@ -37,6 +37,7 @@ run_examples <- function(pkg = ".", start = NULL, show = deprecated(), run_dontt
   if (!missing(show)) {
     lifecycle::deprecate_warn("2.3.1", "run_examples(show)")
   }
+  rlang::local_interactive(FALSE)
 
   pkg <- as.package(pkg)
 

--- a/R/run-examples.R
+++ b/R/run-examples.R
@@ -65,7 +65,7 @@ run_examples <- function(pkg = ".", start = NULL, show = deprecated(), run_dontt
   load_all(pkg$path, reset = TRUE, export_all = FALSE)
   on.exit(load_all(pkg$path, reset = TRUE))
 
-  lapply(files, pkgload::run_example, run_donttest = run_donttest, run_dontrun = run_dontrun)
+  purrr::walk(files, function(x) pkgload::run_example(x, run_donttest = run_donttest, run_dontrun = run_dontrun))
 
   invisible()
 }


### PR DESCRIPTION
I will test this to see if it works as expected.

purrr is imported by pkgdown, usethis, profvis, and roxygen2, so doesn't add a dep.