### PR TITLE
Fix typo with backticks in `check(vignette)` argument

### DIFF
--- a/R/check.R
+++ b/R/check.R
@@ -44,7 +44,7 @@
 #' @param build_args Additional arguments passed to `R CMD build`
 #' @param ... Additional arguments passed on to [pkgbuild::build()].
 #' @param vignettes If `FALSE`, do not build or check vignettes, equivalent to
-#'   using `args = '--ignore-vignettes' and `build_args = '--no-build-vignettes'.
+#'   using `args = '--ignore-vignettes'` and `build_args = '--no-build-vignettes'`.
 #' @param cleanup `r lifecycle::badge("deprecated")` See `check_dir` for details.
 #' @seealso [release()] if you want to send the checked package to
 #'   CRAN.

--- a/man/check.Rd
+++ b/man/check.Rd
@@ -92,7 +92,7 @@ is cleaned up when the returned object is garbage collected.}
 \item{cleanup}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} See \code{check_dir} for details.}
 
 \item{vignettes}{If \code{FALSE}, do not build or check vignettes, equivalent to
-using \verb{args = '--ignore-vignettes' and }build_args = '--no-build-vignettes'.}
+using \code{args = '--ignore-vignettes'} and \code{build_args = '--no-build-vignettes'}.}
 
 \item{error_on}{Whether to throw an error on \verb{R CMD check} failures. Note
 that the check is always completed (unless a timeout happens), and the


### PR DESCRIPTION
Note: the sentence is 3 characters over 80, but it was already 1 character over initially, so I didn't wrap.