### PR TITLE
Remove `generate_dsym` argument

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,7 +1,5 @@
 # devtools (development version)
 
-* On macOS, `install()` now generates `dSYM` sidecar files for native libraries by default.
-
 * Functions that use httr now explicitly check that it is installed
   (@catalamarti, #2573).
 

--- a/R/install.R
+++ b/R/install.R
@@ -26,6 +26,13 @@
 #'   binary artefacts (like \file{.o}, `.so`) from appearing in your local
 #'   package directory, but is considerably slower, because every compile has
 #'   to start from scratch.
+#'
+#'   One downside of installing from a built tarball is that the package is
+#'   installed from a temporary location. This means that any source references,
+#'   at R level or C/C++ level, will point to dangling locations. The debuggers
+#'   will not be able to find the sources for step-debugging. If you're
+#'   installing the package for development, consider setting `build` to
+#'   `FALSE`.
 #' @param args An optional character vector of additional command line
 #'   arguments to be passed to `R CMD INSTALL`. This defaults to the
 #'   value of the option `"devtools.install.args"`.
@@ -36,27 +43,6 @@
 #' @param keep_source If `TRUE` will keep the srcrefs from an installed
 #'   package. This is useful for debugging (especially inside of RStudio).
 #'   It defaults to the option `"keep.source.pkgs"`.
-#' @param generate_dsym (macOS only) If `TRUE`, and if the package includes a
-#'   native library (a `.so` file), a `dSYM` sidecar file is generated and
-#'   installed alongside the library. This file contains source and line
-#'   information that allows a debugger to step through original sources.
-#'
-#'   Note that when `build` is set to `TRUE`, `install()` operates from a
-#'   temporary directory which causes the source paths to point to dangling
-#'   locations. You will need to remap these paths to the actual sources on your
-#'   disk, e.g. with lldb:
-#'
-#'   ```
-#'   # Get information about the dangling temporary path for a function in your
-#'   # library
-#'   image lookup -vn my_function
-#'
-#'   # Remap the dangling location to the actual package path
-#'   settings set target.source-map /private/tmp/Rtmpnl5XgE/R.INSTALLe5133dcc3211/mypackage /path/to/mypackage
-#'   ```
-#'
-#'   To avoid this, set `build` to `FALSE` to install directly from the source
-#'   location instead of a "built" package tarball.
 #' @param ... additional arguments passed to [remotes::install_deps()]
 #'   when installing dependencies.
 #' @family package installation
@@ -71,7 +57,6 @@ install <-
              build_vignettes = FALSE,
              keep_source = getOption("keep.source.pkgs"),
              force = FALSE,
-             generate_dsym = TRUE,
              ...) {
     pkg <- as.package(pkg)
 
@@ -92,7 +77,6 @@ install <-
 
     opts <- c(
       if (keep_source) "--with-keep.source",
-      if (is_macos && generate_dsym) "--dsym",
       "--install-tests"
     )
     if (quick) {

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -16,7 +16,6 @@ install(
   build_vignettes = FALSE,
   keep_source = getOption("keep.source.pkgs"),
   force = FALSE,
-  generate_dsym = TRUE,
   ...
 )
 }
@@ -34,7 +33,14 @@ demos, and vignettes, to make installation as fast as possible.}
 this ensures that the installation is completely clean, and prevents any
 binary artefacts (like \file{.o}, \code{.so}) from appearing in your local
 package directory, but is considerably slower, because every compile has
-to start from scratch.}
+to start from scratch.
+
+One downside of installing from a built tarball is that the package is
+installed from a temporary location. This means that any source references,
+at R level or C/C++ level, will point to dangling locations. The debuggers
+will not be able to find the sources for step-debugging. If you're
+installing the package for development, consider setting \code{build} to
+\code{FALSE}.}
 
 \item{args}{An optional character vector of additional command line
 arguments to be passed to \verb{R CMD INSTALL}. This defaults to the
@@ -78,27 +84,6 @@ It defaults to the option \code{"keep.source.pkgs"}.}
 
 \item{force}{Force installation, even if the remote state has not changed
 since the previous install.}
-
-\item{generate_dsym}{(macOS only) If \code{TRUE}, and if the package includes a
-native library (a \code{.so} file), a \code{dSYM} sidecar file is generated and
-installed alongside the library. This file contains source and line
-information that allows a debugger to step through original sources.
-
-Note that when \code{build} is set to \code{TRUE}, \code{install()} operates from a
-temporary directory which causes the source paths to point to dangling
-locations. You will need to remap these paths to the actual sources on your
-disk, e.g. with lldb:
-
-\if{html}{\out{<div class="sourceCode">}}\preformatted{# Get information about the dangling temporary path for a function in your
-# library
-image lookup -vn my_function
-
-# Remap the dangling location to the actual package path
-settings set target.source-map /private/tmp/Rtmpnl5XgE/R.INSTALLe5133dcc3211/mypackage /path/to/mypackage
-}\if{html}{\out{</div>}}
-
-To avoid this, set \code{build} to \code{FALSE} to install directly from the source
-location instead of a "built" package tarball.}
 
 \item{...}{additional arguments passed to \code{\link[remotes:install_deps]{remotes::install_deps()}}
 when installing dependencies.}

--- a/man/install_deps.Rd
+++ b/man/install_deps.Rd
@@ -68,7 +68,14 @@ to "always". \code{TRUE} and \code{FALSE} are also accepted and correspond to
 this ensures that the installation is completely clean, and prevents any
 binary artefacts (like \file{.o}, \code{.so}) from appearing in your local
 package directory, but is considerably slower, because every compile has
-to start from scratch.}
+to start from scratch.
+
+One downside of installing from a built tarball is that the package is
+installed from a temporary location. This means that any source references,
+at R level or C/C++ level, will point to dangling locations. The debuggers
+will not be able to find the sources for step-debugging. If you're
+installing the package for development, consider setting \code{build} to
+\code{FALSE}.}
 
 \item{build_opts}{Options to pass to \verb{R CMD build}, only used when \code{build} is \code{TRUE}.}
 


### PR DESCRIPTION
Follow up for https://github.com/r-lib/devtools/pull/2598

It's not necessary to generate a dSYM file if you use `build = FALSE`.

The problem with `build = TRUE` is that if you're not generating dSYM files, the linker inserts paths to object files that contain the DWARF debug info and these paths are pointing to dangling temporary locations:

```
> nm -a /Users/lionel/R/Library/4.4-aarch64/rlang/libs/rlang.so | grep OSO
0000000067ef7d43 - 00 0001   OSO /private/tmp/RtmpIM0xjp/R.INSTALLe9c020cfb3cd/rlang/src/capture.o
0000000067ef7d43 - 00 0001   OSO /private/tmp/RtmpIM0xjp/R.INSTALLe9c020cfb3cd/rlang/src/internal.o
0000000067ef7d43 - 00 0001   OSO /private/tmp/RtmpIM0xjp/R.INSTALLe9c020cfb3cd/rlang/src/rlang.o
0000000067ef7d43 - 00 0001   OSO /private/tmp/RtmpIM0xjp/R.INSTALLe9c020cfb3cd/rlang/src/version.o
```

The workaround implemented in the linked PR is to generate a dSYM file that contains the DWARF info. But this debug info itself points to source files in the dangling temporary directory, forcing the user to remap these files in the debugger, which is quite cumbersome.

With `build = FALSE` the package is installed directly from source so the recorded paths to object files are correct:

```
> nm -a /Users/lionel/R/Library/4.4-aarch64/rlang/libs/rlang.so | grep OSO
0000000067ed4ae1 - 00 0001   OSO /Users/lionel/Sync/Projects/R/r-lib/rlang/src/capture.o
0000000067ef785b - 00 0001   OSO /Users/lionel/Sync/Projects/R/r-lib/rlang/src/internal.o
0000000067ef785b - 00 0001   OSO /Users/lionel/Sync/Projects/R/r-lib/rlang/src/rlang.o
0000000067ed4ae1 - 00 0001   OSO /Users/lionel/Sync/Projects/R/r-lib/rlang/src/version.o
```

There is no need to generate a dSYM file in that case. The only advantage of that file is that you are allowed to delete the object files in the source repo and still preserve full debug information but in practice I think most of us keep their `src` directory dirty.

Generating these files gets in the way of various dev workflows since they are not ignored by default so it's better not to have to deal with those. For instance I saw that NOTE during check:

```
N  checking if this is a source package ...
   Found the following apparent object files/libraries:
     src/rlang.so.dSYM/Contents/Resources/DWARF/rlang.so
   Object files/libraries should not be included in a source package.
```