### PR TITLE
fix typo

### DIFF
--- a/R/run-source.R
+++ b/R/run-source.R
@@ -104,7 +104,7 @@ check_sha1 <- function(path, sha1) {
 #' # Wrong hash will result in error
 #' source_gist(6872663, sha1 = "54f1db27e61")
 #'
-#' #' # You can speficy a particular R file in the gist
+#' #' # You can specify a particular R file in the gist
 #' source_gist(6872663, filename = "hi.r")
 #' source_gist(6872663, filename = "hi.r", sha1 = "54f1db27e60")
 #' }

--- a/man/load_all.Rd
+++ b/man/load_all.Rd
@@ -17,11 +17,9 @@ load_all(
 \arguments{
 \item{path}{Path to a package, or within a package.}
 
-\item{reset}{clear package environment and reset file cache before loading
-any pieces of the package. This largely equivalent to running
-\code{\link[pkgload:unload]{unload()}}, however the old namespaces are not completely removed and no
-\code{.onUnload()} hooks are called. Use \code{reset = FALSE} may be faster for
-large code bases, but is a significantly less accurate approximation.}
+\item{reset}{\ifelse{html}{\href{https://lifecycle.r-lib.org/articles/stages.html#deprecated}{\figure{lifecycle-deprecated.svg}{options: alt='[Deprecated]'}}}{\strong{[Deprecated]}} This is no longer supported
+because preserving the namespace requires unlocking its environment, which
+is no longer possible in recent versions of R.}
 
 \item{recompile}{DEPRECATED. force a recompile of DLL from source code, if
 present. This is equivalent to running \code{\link[pkgbuild:clean_dll]{pkgbuild::clean_dll()}} before
@@ -67,6 +65,8 @@ helpers are run during package loading.
 
 \code{is_loading()} returns \code{TRUE} when it is called while \code{load_all()}
 is running. This may be useful e.g. in \code{.onLoad} hooks.
+A package loaded with \code{load_all()} can be identified with with
+\code{\link[pkgload:is_dev_package]{is_dev_package()}}.
 }
 \section{Differences to regular loading}{
 
@@ -101,9 +101,6 @@ load_all("./")
 
 # Running again loads changed files
 load_all("./")
-
-# With reset=TRUE, unload and reload the package for a clean start
-load_all("./", TRUE)
 
 # With export_all=FALSE, only objects listed as exports in NAMESPACE
 # are exported

--- a/man/reexports.Rd
+++ b/man/reexports.Rd
@@ -16,6 +16,11 @@
 \alias{session_info}
 \alias{package_info}
 \title{Objects exported from other packages}
+\usage{
+github_pull(pull)
+
+github_release()
+}
 \keyword{internal}
 \description{
 These objects are imported from other packages. Follow the links
@@ -25,8 +30,6 @@ below to see their documentation.
   \item{pkgbuild}{\code{\link[pkgbuild]{clean_dll}}, \code{\link[pkgbuild:has_rtools]{find_rtools}}, \code{\link[pkgbuild:has_compiler]{has_devel}}, \code{\link[pkgbuild]{with_debug}}}
 
   \item{pkgload}{\code{\link[pkgload]{check_dep_version}}, \code{\link[pkgload]{parse_deps}}, \code{\link[pkgload]{unload}}}
-
-  \item{remotes}{\code{\link[remotes:github_refs]{github_pull}}, \code{\link[remotes:github_refs]{github_release}}}
 
   \item{sessioninfo}{\code{\link[sessioninfo]{package_info}}, \code{\link[sessioninfo]{session_info}}}
 }}

--- a/man/source_gist.Rd
+++ b/man/source_gist.Rd
@@ -46,7 +46,7 @@ source_gist(6872663, sha1 = "54f1db27e60")
 # Wrong hash will result in error
 source_gist(6872663, sha1 = "54f1db27e61")
 
-#' # You can speficy a particular R file in the gist
+#' # You can specify a particular R file in the gist
 source_gist(6872663, filename = "hi.r")
 source_gist(6872663, filename = "hi.r", sha1 = "54f1db27e60")
 }


### PR DESCRIPTION
dumped repo strings exposed a solitary typo

running `roxygen2::roxygenise()` further modified additional files