### PR TITLE
test upkeep

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -65,6 +65,7 @@ VignetteBuilder:
     knitr
 Config/Needs/website: tidyverse/tidytemplate
 Config/testthat/edition: 3
+Config/testthat/parallel: true
 Encoding: UTF-8
 Language: en-US
 Roxygen: list(markdown = TRUE)

--- a/tests/testthat/_snaps/build-site.md
+++ b/tests/testthat/_snaps/build-site.md
@@ -1,0 +1,8 @@
+# Package pkgdown site can be built 
+
+    Code
+      build_site(path = "testPkgdown", override = list(destination = destination))
+    Message
+      -- Installing package testPkgdown into temporary library -----------------------
+      -- Finished building pkgdown site for package testPkgdown ----------------------
+

--- a/tests/testthat/_snaps/check-doc.md
+++ b/tests/testthat/_snaps/check-doc.md
@@ -1,0 +1,19 @@
+# check_man works
+
+    Code
+      check_man(pkg)
+    Message
+      i Updating {package} documentation
+      i Loading {package}
+      i Checking documentation...
+    Output
+      Rd files without \alias:
+        'foo.Rd'
+      Rd files without \description:
+        'foo.Rd'
+      Argument items with no description in Rd file 'foo.Rd':
+        'foo'
+      Undocumented arguments in Rd file 'foo.Rd'
+        'x'
+      
+

--- a/tests/testthat/test-build-site.R
+++ b/tests/testthat/test-build-site.R
@@ -5,36 +5,13 @@ test_that("Package pkgdown site can be built ", {
 
   destination <- path(tempdir(), "testPkgdown", "docs")
 
-  build_output <- capture.output(
-    {
-      build_site(
-        path = "testPkgdown",
-        override = list(destination = destination)
-      )
-    },
-    type = c("output")
-  )
+  expect_snapshot(build_site(
+    path = "testPkgdown",
+    override = list(destination = destination)
+  ))
 
-  build_output <- paste(build_output, collapse = "\n")
-
-  expect_true(
-    file_exists(path(destination, "index.html")),
-    info = build_output,
-    label = "created site index"
-  )
-  expect_true(
-    file_exists(path(destination, "reference", "index.html")),
-    info = build_output,
-    label = "created reference index"
-  )
-  expect_true(
-    file_exists(path(destination, "articles", "index.html")),
-    info = build_output,
-    label = "created articles index"
-  )
-  expect_true(
-    file_exists(path(destination, "articles", "test.html")),
-    info = build_output,
-    label = "created articles index"
-  )
+  expect_true(file_exists(path(destination, "index.html")))
+  expect_true(file_exists(path(destination, "reference", "index.html")))
+  expect_true(file_exists(path(destination, "articles", "index.html")))
+  expect_true(file_exists(path(destination, "articles", "test.html")))
 })

--- a/tests/testthat/test-check-doc.R
+++ b/tests/testthat/test-check-doc.R
@@ -21,8 +21,8 @@ foo(x)
     file.path(pkg, "man", "foo.Rd")
   )
 
-  expect_output(
+  expect_snapshot(
     check_man(pkg),
-    "Undocumented arguments"
+    transform = \(x) gsub(basename(pkg), "{package}", x, fixed = TRUE)
   )
 })


### PR DESCRIPTION
* Prevent output from escaping by switching to `expect_snapshot()`
* Run tests in parallel