### PR TITLE
Pass the current lib paths

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -25,7 +25,7 @@ Imports:
     lifecycle (>= 1.0.5),
     memoise (>= 2.0.1),
     miniUI (>= 0.1.2),
-    pak (>= 0.9.3),
+    pak (>= 0.9.5),
     pkgbuild (>= 1.4.8),
     pkgdown (>= 2.2.0),
     pkgload (>= 1.5.1),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,6 +1,6 @@
 # devtools (development version)
 
-* `install()` uses a new feature of `pak::local_install_deps()` to consider the current `.libPaths()` when resolving dependencies, instead of consulting only `.libPaths()[1]`. This was an unintended behavioural change introduced in 2.5.0 (#2691).
+* `install()` uses a new feature of `pak::local_install_deps()` to consider the current `.libPaths()` when resolving dependencies, instead of consulting only `.libPaths()[1]`. This was an unintended behavioral change introduced in 2.5.0 (#2691).
 
 # devtools 2.5.1
 

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools (development version)
 
+* `install()` uses a new feature of `pak::local_install_deps()` to consider the current `.libPaths()` when resolving dependencies, instead of consulting only `.libPaths()[1]`. This was an unintended behavioural change introduced in 2.5.0 (#2691).
+
 # devtools 2.5.1
 
 * `build_readme()` no longer installs dependencies into the temporary library

--- a/R/install.R
+++ b/R/install.R
@@ -87,6 +87,7 @@ install <- function(
       withCallingHandlers(
         pak::local_install_deps(
           pkg$path,
+          lib = .libPaths(),
           upgrade = upgrade,
           dependencies = dependencies || isTRUE(build_vignettes)
         ),
@@ -96,6 +97,7 @@ install <- function(
       cli::cat_rule("pak::local_install_deps()", col = "cyan")
       pak::local_install_deps(
         pkg$path,
+        lib = .libPaths(),
         upgrade = upgrade,
         dependencies = dependencies || isTRUE(build_vignettes)
       )

--- a/man/install.Rd
+++ b/man/install.Rd
@@ -68,7 +68,7 @@ information about package dependencies.
 of work to give you the latest version(s) of \code{pkg}. It will only upgrade
 dependent packages if \code{pkg}, or one of their dependencies explicitly
 require a higher version than what you currently have. It will also
-prefer a binary package over to source package, even it the binary
+prefer a binary package over to source package, even if the binary
 package is older.
 
 When \code{upgrade = TRUE}, pak will ensure that you have the latest

--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -21,6 +21,22 @@ test_that("install reports stages", {
   )
 })
 
+test_that("install() doesn't reinstall deps already in non-primary libpath", {
+  skip_on_cran()
+
+  pkg <- local_package_copy(test_path("testInstallWithDeps"))
+  withr::local_temp_libpaths()
+  tmp_lib <- .libPaths()[1]
+
+  install(pkg, reload = FALSE, build = FALSE, quiet = TRUE)
+
+  installed <- setdiff(
+    fs::path_file(fs::dir_ls(tmp_lib, type = "directory")),
+    "_cache"
+  )
+  expect_equal(installed, "testInstallWithDeps")
+})
+
 test_that("vignettes built on install", {
   skip_on_cran()
 

--- a/tests/testthat/testInstallWithDeps/DESCRIPTION
+++ b/tests/testthat/testInstallWithDeps/DESCRIPTION
@@ -1,0 +1,10 @@
+Package: testInstallWithDeps
+Title: Test Package With Dependencies
+Version: 0.1.0
+Authors@R: person("Test", "User", role = c("aut", "cre"), email = "test@example.com")
+Description: Minimal package used to test that devtools::install() does not
+    reinstall dependencies that are already satisfied in a non-primary library.
+License: GPL-2
+Imports:
+    cli
+Encoding: UTF-8

--- a/tests/testthat/testInstallWithDeps/NAMESPACE
+++ b/tests/testthat/testInstallWithDeps/NAMESPACE
@@ -1,0 +1,1 @@
+importFrom(cli,cli_abort)

--- a/tests/testthat/testInstallWithDeps/R/hello.R
+++ b/tests/testthat/testInstallWithDeps/R/hello.R
@@ -1,0 +1,6 @@
+hello <- function(x) {
+  if (!is.character(x)) {
+    cli::cli_abort("{.arg x} must be a character string.")
+  }
+  paste0("Hello, ", x, "!")
+}


### PR DESCRIPTION
Fixes #2691 

~*However*, we need a change in pak first. See issue https://github.com/r-lib/pak/issues/865 and PR https://github.com/r-lib/pak/pull/864. That change has to be in a pak release so I can bump the minimum pak version for devtools, then merge this.~ *This has happened now.*