### PR TITLE
Make sure cli is installed in `.libPaths()[2]`

### DIFF
--- a/tests/testthat/test-install.R
+++ b/tests/testthat/test-install.R
@@ -21,10 +21,26 @@ test_that("install reports stages", {
   )
 })
 
-test_that("install() doesn't reinstall deps already in non-primary libpath", {
+test_that("install() doesn't reinstall deps that are already installed", {
   skip_on_cran()
 
   pkg <- local_package_copy(test_path("testInstallWithDeps"))
+
+  # Install cli into a temp lib via pak, to make extra sure that
+  # pak considers it already satisfied when install() runs.
+  withr::local_temp_libpaths()
+
+  # It's very hard to silence pak.
+  local({
+    withr::local_output_sink(withr::local_tempfile())
+    withr::local_message_sink(withr::local_tempfile())
+    withCallingHandlers(
+      pak::pkg_install("cli", lib = .libPaths()[1], ask = FALSE),
+      callr_message = function(cnd) tryInvokeRestart("muffleMessage")
+    )
+  })
+
+  # Prepend a second temp lib in which to install the in-development package.
   withr::local_temp_libpaths()
   tmp_lib <- .libPaths()[1]
 


### PR DESCRIPTION
I don't understand how this test can be brittle and yet it has failed once: https://github.com/r-lib/devtools/actions/runs/25173878432/job/73800519118. It failed on retry as well and notably it's a cache miss re: setting up R dependencies:

```
Cache not found for input keys: macOS Sequoia 15.7.4-R version 4.6.0 (2026-04-24)-aarch64-1-46c104b8b7bd9f1e9303c0a9f6f871cc48555d9b4498060900dd0f901bfac1c7, macOS Sequoia 15.7.4-R version 4.6.0 (2026-04-24)-aarch64-1-
```

```
══ Failed tests ════════════════════════════════════════════════════════════════
── Failure ('test-install.R:37:3'): install() doesn't reinstall deps already in non-primary libpath ──
Expected `installed` to equal "testInstallWithDeps".
Differences:
`actual`:   "cli" "testInstallWithDeps"
`expected`:       "testInstallWithDeps"


[ FAIL 1 | WARN 0 | SKIP 7 | PASS 139 ]
```

I feel like it could be some buglet in pak? Or very subtle thing about our GHA config? But neither is in scope for devtools, so let's just harden the test.

Earlier macos-latest GHA runs succeeded with practically the same devtools code and I see:

```
Cache hit for: macOS Sequoia 15.7.4-R version 4.6.0 (2026-04-24)-1-a3e6a6a4321bed33fbcd758f3191ac818942771c229fd4b72fc1a86a3bb9b130
...
Cache restored successfully
Cache restored from key: macOS Sequoia 15.7.4-R version 4.6.0 (2026-04-24)-1-a3e6a6a4321bed33fbcd758f3191ac818942771c229fd4b72fc1a86a3bb9b130
```