### PR TITLE
feat: adds check for bug reports url in release_checks().

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,7 @@
 # devtools (development version)
 
+* `release_checks()` now flags when `BugReports` is missing from DESCRIPTION.
+
 # devtools 2.5.2
 
 * `install()` uses a new feature of `pak::local_install_deps()` to consider the current `.libPaths()` when resolving dependencies, instead of consulting only `.libPaths()[1]`. This was an unintended behavioral change introduced in 2.5.0 (#2691).

--- a/R/check-devtools.R
+++ b/R/check-devtools.R
@@ -15,6 +15,7 @@ release_checks <- function(pkg = ".", built_path = NULL) {
   check_vignette_titles(pkg)
   check_news_md(pkg)
   check_remotes(pkg)
+  check_bug_reports(pkg)
 
   cli::cat_rule()
 }
@@ -123,6 +124,15 @@ check_remotes <- function(pkg) {
 
 has_dev_remotes <- function(pkg) {
   !is.null(pkg[["remotes"]])
+}
+
+check_bug_reports <- function(pkg = ".") {
+  pkg <- as.package(pkg)
+  check_status(
+    !is.null(pkg[["bugreports"]]),
+    "DESCRIPTION has a BugReports field",
+    "DESCRIPTION is missing a BugReports field."
+  )
 }
 
 check_status <- function(status, name, warning) {

--- a/tests/testthat/_snaps/check-devtools.md
+++ b/tests/testthat/_snaps/check-devtools.md
@@ -1,0 +1,16 @@
+# check_bug_reports() passes when BugReports is present
+
+    Code
+      check_bug_reports(dir)
+    Output
+      Checking DESCRIPTION has a BugReports field... OK
+
+# check_bug_reports() warns when BugReports is missing
+
+    Code
+      check_bug_reports(dir)
+    Output
+      Checking DESCRIPTION has a BugReports field...
+    Message
+      x WARNING: DESCRIPTION is missing a BugReports field.
+

--- a/tests/testthat/test-check-devtools.R
+++ b/tests/testthat/test-check-devtools.R
@@ -1,0 +1,14 @@
+test_that("check_bug_reports() passes when BugReports is present", {
+  dir <- local_package_create()
+  desc::desc_set(
+    "BugReports",
+    "https://github.com/example/pkg/issues",
+    file = dir
+  )
+  expect_snapshot(check_bug_reports(dir))
+})
+
+test_that("check_bug_reports() warns when BugReports is missing", {
+  dir <- local_package_create()
+  expect_snapshot(check_bug_reports(dir))
+})


### PR DESCRIPTION
This comes after some discussions during the [R Dev Day](https://pretix.eu/r-contributors/r-dev-day-rr2026/) today, in particular related to https://github.com/r-devel/r-dev-day/issues/153.

About half of CRAN packages don't have a bug reports URL so the CRAN team cannot reach out to them in case email delivery is also broken.

By adding this check to release_checks, at least maintainers will see a warning that they don't have the URL in DESCRIPTION and maybe they decide to add it. 