### PR TITLE
Fix dev_sitrep ignored dependencies installation and add related tests

### DIFF
--- a/NEWS.md
+++ b/NEWS.md
@@ -1,5 +1,6 @@
 # devtools (development version)
 
+* `dev_sitrep()` now suggests `pak::pak("devtools", upgrade = TRUE)` for dependencies that are out of date, because the previously suggested `pak::pak("devtools")` does not upgrade dependencies that are already installed and therefore left the report unchanged (#2702).
 * `submit_cran()` gives a more informative error when the CRAN submission form can't be used, suggesting that the user consult <https://cran.r-project.org> to see if there's a CRAN closure (#2700).
 
 # devtools 2.5.2

--- a/R/install.R
+++ b/R/install.R
@@ -277,7 +277,7 @@ local_install <- function(
   report_deps_ahead_behind(
     dep_status,
     pkg_name = pkg$package,
-    update_code = "pak::local_install_dev_deps()"
+    install_code = "pak::local_install_dev_deps()"
   )
 
   if (!quiet) {

--- a/R/sitrep.R
+++ b/R/sitrep.R
@@ -215,7 +215,8 @@ print.dev_sitrep <- function(x, ...) {
     report_deps_ahead_behind(
       x$devtools_deps,
       pkg_name = "devtools",
-      update_code = 'pak::pak("devtools")'
+      install_code = 'pak::pak("devtools")',
+      upgrade_code = 'pak::pak("devtools", upgrade = TRUE)'
     )
   }
 
@@ -229,7 +230,7 @@ print.dev_sitrep <- function(x, ...) {
     report_deps_ahead_behind(
       x$pkg_deps,
       pkg_name = x$pkg$package,
-      update_code = "pak::local_install_dev_deps()"
+      install_code = "pak::local_install_dev_deps()"
     )
   }
 
@@ -297,16 +298,22 @@ pkg_dep_status <- function(pkg, dependencies = NA) {
 #' @param dep_status A data frame as returned by `compare_deps()`, with
 #'   columns `package`, `latest`, `installed`, `status`.
 #' @param pkg_name Package name to mention in the message.
-#' @param update_code Code suggestion for updating behind deps.
+#' @param install_code Code suggestion for installing missing deps.
+#' @param upgrade_code Code suggestion for updating behind deps.
 #' @return Called for its side effects.
 #' @noRd
-report_deps_ahead_behind <- function(dep_status, pkg_name, update_code) {
+report_deps_ahead_behind <- function(
+  dep_status,
+  pkg_name,
+  install_code,
+  upgrade_code = install_code
+) {
   missing <- dep_status[dep_status$status == "missing", ]
   if (nrow(missing) > 0) {
     n <- nrow(missing)
     cli::cli_bullets(c(
       "!" = "{n} {.field {pkg_name}} {cli::qty(n)}{?dependency is/dependencies are} not installed.",
-      " " = "Install {cli::qty(n)}{?it/them} with {.run {update_code}}."
+      " " = "Install {cli::qty(n)}{?it/them} with {.run {install_code}}."
     ))
     cli::cli_verbatim(paste("  ", dep_labels(missing)))
   }
@@ -316,7 +323,7 @@ report_deps_ahead_behind <- function(dep_status, pkg_name, update_code) {
     n <- nrow(behind)
     cli::cli_bullets(c(
       "!" = "{n} {.field {pkg_name}} {cli::qty(n)}{?dependency is/dependencies are} out of date.",
-      " " = "Update {cli::qty(n)}{?it/them} with {.run {update_code}}."
+      " " = "Update {cli::qty(n)}{?it/them} with {.run {upgrade_code}}."
     ))
     cli::cli_verbatim(paste("  ", dep_labels(behind)))
   }

--- a/tests/testthat/_snaps/sitrep.md
+++ b/tests/testthat/_snaps/sitrep.md
@@ -71,7 +71,7 @@
       -- devtools ------------------------------------------------
       * version: 2.4.6
       ! 1 devtools dependency is out of date.
-        Update it with `pak::pak("devtools")`.
+        Update it with `pak::pak("devtools", upgrade = TRUE)`.
          cli (behind: 0.5.0 vs 1.0.0)
       -- dev package ---------------------------------------------
       * package: <unset>
@@ -90,6 +90,26 @@
       ! 1 devtools dependency is not installed.
         Install it with `pak::pak("devtools")`.
          somepkg (missing)
+      -- dev package ---------------------------------------------
+      * package: <unset>
+      * path: <unset>
+
+# print suggests upgrade = TRUE only for out-of-date deps
+
+    Code
+      print(x)
+    Message
+      -- R -------------------------------------------------------
+      * version: 4.4.0
+      * path: '/usr/lib/R'
+      -- devtools ------------------------------------------------
+      * version: 2.4.6
+      ! 1 devtools dependency is not installed.
+        Install it with `pak::pak("devtools")`.
+         rlang (missing)
+      ! 1 devtools dependency is out of date.
+        Update it with `pak::pak("devtools", upgrade = TRUE)`.
+         cli (behind: 0.5.0 vs 1.0.0)
       -- dev package ---------------------------------------------
       * package: <unset>
       * path: <unset>

--- a/tests/testthat/test-sitrep.R
+++ b/tests/testthat/test-sitrep.R
@@ -73,6 +73,22 @@ test_that("print warns about missing devtools deps", {
   expect_snapshot(print(x))
 })
 
+test_that("print suggests upgrade = TRUE only for out-of-date deps", {
+  local_reproducible_output(width = 60)
+  x <- new_dev_sitrep(
+    r_version = R_system_version("4.4.0"),
+    r_path = "/usr/lib/R",
+    devtools_version = package_version("2.4.6"),
+    devtools_deps = data.frame(
+      package = c("rlang", "cli"),
+      latest = c("1.0.0", "1.0.0"),
+      installed = c(NA_character_, "0.5.0"),
+      status = c("missing", "behind")
+    )
+  )
+  expect_snapshot(print(x))
+})
+
 test_that("print notes dev versions of devtools deps", {
   local_reproducible_output(width = 60)
   x <- new_dev_sitrep(


### PR DESCRIPTION
> Analysis and draft assisted by an AI tool; I reproduced, reviewed and tested the
> change myself.

`dev_sitrep()` now suggests `pak::pak("devtools", upgrade = TRUE)` for dependencies that are out of date, because the previously suggested `pak::pak("devtools")` does not upgrade dependencies that are already installed and therefore left the report unchanged. Closes #2702